### PR TITLE
STM32: fixed and separated H7 Configuration-related checks for H743/H753

### DIFF
--- a/os/hal/ports/STM32/STM32H7xx/hal_lld.h
+++ b/os/hal/ports/STM32/STM32H7xx/hal_lld.h
@@ -1217,9 +1217,14 @@
 #error "Using a wrong mcuconf.h file, STM32H7xx_MCUCONF not defined"
 #endif
 
-#if (defined(STM32H743xx) || defined(STM32H753xx)) &&                       \
+#if defined(STM32H743xx) &&                       \
     !defined(STM32H743_MCUCONF)
 #error "Using a wrong mcuconf.h file, STM32H743_MCUCONF not defined"
+#endif
+
+#if defined(STM32H753xx) &&                       \
+    !defined(STM32H753_MCUCONF)
+#error "Using a wrong mcuconf.h file, STM32H753_MCUCONF not defined"
 #endif
 
 /*


### PR DESCRIPTION
@tridge - this was causing my build to fail when I specified "MCU STM32H7xx STM32H753xx" in my new hwdef.dat file.