### PR TITLE
i2c: add soft stop option

### DIFF
--- a/os/hal/include/hal_i2c.h
+++ b/os/hal/include/hal_i2c.h
@@ -140,6 +140,7 @@ extern "C" {
   void i2cObjectInit(I2CDriver *i2cp);
   void i2cStart(I2CDriver *i2cp, const I2CConfig *config);
   void i2cStop(I2CDriver *i2cp);
+  void i2cSoftStop(I2CDriver *i2cp);
   i2cflags_t i2cGetErrors(I2CDriver *i2cp);
   msg_t i2cMasterTransmitTimeout(I2CDriver *i2cp,
                                  i2caddr_t addr,

--- a/os/hal/lib/fallback/I2C/hal_i2c_lld.c
+++ b/os/hal/lib/fallback/I2C/hal_i2c_lld.c
@@ -325,6 +325,18 @@ void i2c_lld_stop(I2CDriver *i2cp) {
 }
 
 /**
+ * @brief   Deactivates the I2C peripheral.
+ *
+ * @param[in] i2cp      pointer to the @p I2CDriver object
+ *
+ * @notapi
+ */
+void i2c_lld_soft_stop(I2CDriver *i2cp) {
+  /* just stop if there's no "soft stop option" */
+  i2c_lld_stop(i2cp);
+}
+
+/**
  * @brief   Receives data via the I2C bus as master.
  *
  * @param[in] i2cp      pointer to the @p I2CDriver object

--- a/os/hal/lib/fallback/I2C/hal_i2c_lld.h
+++ b/os/hal/lib/fallback/I2C/hal_i2c_lld.h
@@ -214,6 +214,7 @@ extern "C" {
   void i2c_lld_init(void);
   void i2c_lld_start(I2CDriver *i2cp);
   void i2c_lld_stop(I2CDriver *i2cp);
+  void i2c_lld_soft_stop(I2CDriver *i2cp);
   msg_t i2c_lld_master_transmit_timeout(I2CDriver *i2cp, i2caddr_t addr,
                                         const uint8_t *txbuf, size_t txbytes,
                                         uint8_t *rxbuf, size_t rxbytes,

--- a/os/hal/ports/STM32/LLD/I2Cv1/hal_i2c_lld.c
+++ b/os/hal/ports/STM32/LLD/I2Cv1/hal_i2c_lld.c
@@ -736,6 +736,48 @@ void i2c_lld_stop(I2CDriver *i2cp) {
 }
 
 /**
+ * @brief   Disable DMA, disable interrupts, but leave the peripheral enabled
+ *
+ * @param[in] i2cp      pointer to the @p I2CDriver object
+ *
+ * @notapi
+ */
+void i2c_lld_soft_stop(I2CDriver *i2cp) {
+
+  /* If not in stopped state then disables the I2C clock.*/
+  if (i2cp->state != I2C_STOP) {
+
+    /* I2C disable.*/
+    dmaStreamFreeI(i2cp->dmatx);
+    dmaStreamFreeI(i2cp->dmarx);
+    i2cp->dmatx = NULL;
+    i2cp->dmarx = NULL;
+
+#if STM32_I2C_USE_I2C1
+    if (&I2CD1 == i2cp) {
+      nvicDisableVector(I2C1_EV_IRQn);
+      nvicDisableVector(I2C1_ER_IRQn);
+    }
+#endif
+
+#if STM32_I2C_USE_I2C2
+    if (&I2CD2 == i2cp) {
+      nvicDisableVector(I2C2_EV_IRQn);
+      nvicDisableVector(I2C2_ER_IRQn);
+    }
+#endif
+
+#if STM32_I2C_USE_I2C3
+    if (&I2CD3 == i2cp) {
+      nvicDisableVector(I2C3_EV_IRQn);
+      nvicDisableVector(I2C3_ER_IRQn);
+    }
+#endif
+  }
+}
+
+
+/**
  * @brief   Receives data via the I2C bus as master.
  * @details Number of receiving bytes must be more than 1 on STM32F1x. This is
  *          hardware restriction.

--- a/os/hal/ports/STM32/LLD/I2Cv1/hal_i2c_lld.h
+++ b/os/hal/ports/STM32/LLD/I2Cv1/hal_i2c_lld.h
@@ -499,6 +499,7 @@ extern "C" {
   void i2c_lld_init(void);
   void i2c_lld_start(I2CDriver *i2cp);
   void i2c_lld_stop(I2CDriver *i2cp);
+  void i2c_lld_soft_stop(I2CDriver *i2cp);
   msg_t i2c_lld_master_transmit_timeout(I2CDriver *i2cp, i2caddr_t addr,
                                         const uint8_t *txbuf, size_t txbytes,
                                         uint8_t *rxbuf, size_t rxbytes,

--- a/os/hal/ports/STM32/LLD/I2Cv2/hal_i2c_lld.c
+++ b/os/hal/ports/STM32/LLD/I2Cv2/hal_i2c_lld.c
@@ -933,6 +933,79 @@ void i2c_lld_stop(I2CDriver *i2cp) {
 }
 
 /**
+ * @brief   Disable DMA, disable interrupts, but leave the peripheral enabled
+ *
+ * @param[in] i2cp      pointer to the @p I2CDriver object
+ *
+ * @notapi
+ */
+void i2c_lld_soft_stop(I2CDriver *i2cp) {
+
+  /* If not in stopped state then disables the I2C clock.*/
+  if (i2cp->state != I2C_STOP) {
+
+#if STM32_I2C_USE_DMA == TRUE
+    dmaStreamFreeI(i2cp->dmatx);
+    dmaStreamFreeI(i2cp->dmarx);
+    i2cp->dmatx = NULL;
+    i2cp->dmarx = NULL;
+#endif
+
+#if STM32_I2C_USE_I2C1
+    if (&I2CD1 == i2cp) {
+#if defined(STM32_I2C1_GLOBAL_NUMBER) || defined(__DOXYGEN__)
+      nvicDisableVector(STM32_I2C1_GLOBAL_NUMBER);
+#elif defined(STM32_I2C1_EVENT_NUMBER) && defined(STM32_I2C1_ERROR_NUMBER)
+      nvicDisableVector(STM32_I2C1_EVENT_NUMBER);
+      nvicDisableVector(STM32_I2C1_ERROR_NUMBER);
+#else
+#error "I2C1 interrupt numbers not defined"
+#endif
+    }
+#endif
+
+#if STM32_I2C_USE_I2C2
+    if (&I2CD2 == i2cp) {
+#if defined(STM32_I2C2_GLOBAL_NUMBER) || defined(__DOXYGEN__)
+      nvicDisableVector(STM32_I2C2_GLOBAL_NUMBER);
+#elif defined(STM32_I2C2_EVENT_NUMBER) && defined(STM32_I2C2_ERROR_NUMBER)
+      nvicDisableVector(STM32_I2C2_EVENT_NUMBER);
+      nvicDisableVector(STM32_I2C2_ERROR_NUMBER);
+#else
+#error "I2C2 interrupt numbers not defined"
+#endif
+    }
+#endif
+
+#if STM32_I2C_USE_I2C3
+    if (&I2CD3 == i2cp) {
+#if defined(STM32_I2C3_GLOBAL_NUMBER) || defined(__DOXYGEN__)
+      nvicDisableVector(STM32_I2C3_GLOBAL_NUMBER);
+#elif defined(STM32_I2C3_EVENT_NUMBER) && defined(STM32_I2C3_ERROR_NUMBER)
+      nvicDisableVector(STM32_I2C3_EVENT_NUMBER);
+      nvicDisableVector(STM32_I2C3_ERROR_NUMBER);
+#else
+#error "I2C3 interrupt numbers not defined"
+#endif
+    }
+#endif
+
+#if STM32_I2C_USE_I2C4
+    if (&I2CD4 == i2cp) {
+#if defined(STM32_I2C4_GLOBAL_NUMBER) || defined(__DOXYGEN__)
+      nvicDisableVector(STM32_I2C4_GLOBAL_NUMBER);
+#elif defined(STM32_I2C4_EVENT_NUMBER) && defined(STM32_I2C4_ERROR_NUMBER)
+      nvicDisableVector(STM32_I2C4_EVENT_NUMBER);
+      nvicDisableVector(STM32_I2C4_ERROR_NUMBER);
+#else
+#error "I2C4 interrupt numbers not defined"
+#endif
+    }
+#endif
+  }
+}
+
+/**
  * @brief   Receives data via the I2C bus as master.
  *
  * @param[in] i2cp      pointer to the @p I2CDriver object

--- a/os/hal/ports/STM32/LLD/I2Cv2/hal_i2c_lld.h
+++ b/os/hal/ports/STM32/LLD/I2Cv2/hal_i2c_lld.h
@@ -486,6 +486,7 @@ extern "C" {
   void i2c_lld_init(void);
   void i2c_lld_start(I2CDriver *i2cp);
   void i2c_lld_stop(I2CDriver *i2cp);
+  void i2c_lld_soft_stop(I2CDriver *i2cp);
   msg_t i2c_lld_master_transmit_timeout(I2CDriver *i2cp, i2caddr_t addr,
                                         const uint8_t *txbuf, size_t txbytes,
                                         uint8_t *rxbuf, size_t rxbytes,

--- a/os/hal/ports/STM32/LLD/I2Cv3/hal_i2c_lld.c
+++ b/os/hal/ports/STM32/LLD/I2Cv3/hal_i2c_lld.c
@@ -1026,6 +1026,43 @@ void i2c_lld_stop(I2CDriver *i2cp) {
 }
 
 /**
+ * @brief   Disable DMA, but leave the peripheral enabled
+ *
+ * @param[in] i2cp      pointer to the @p I2CDriver object
+ *
+ * @notapi
+ */
+void i2c_lld_soft_stop(I2CDriver *i2cp) {
+
+  /* If not in stopped state then disables the I2C clock.*/
+  if (i2cp->state != I2C_STOP) {
+
+#if defined(STM32_I2C_DMA_REQUIRED) && defined(STM32_I2C_BDMA_REQUIRED)
+    if(i2cp->is_bdma)
+#endif
+#if defined(STM32_I2C_BDMA_REQUIRED)
+    {
+      bdmaStreamFreeI(i2cp->rx.bdma);
+      i2cp->rx.bdma = NULL;
+      bdmaStreamFreeI(i2cp->tx.bdma);
+      i2cp->tx.bdma = NULL;
+    }
+#endif
+#if defined(STM32_I2C_DMA_REQUIRED) && defined(STM32_I2C_BDMA_REQUIRED)
+    else
+#endif
+#if defined(STM32_I2C_DMA_REQUIRED)
+    {
+      dmaStreamFreeI(i2cp->rx.dma);
+      i2cp->rx.dma = NULL;
+      dmaStreamFreeI(i2cp->tx.dma);
+      i2cp->tx.dma = NULL;
+    }
+#endif
+  }
+}
+
+/**
  * @brief   Receives data via the I2C bus as master.
  *
  * @param[in] i2cp      pointer to the @p I2CDriver object

--- a/os/hal/ports/STM32/LLD/I2Cv3/hal_i2c_lld.h
+++ b/os/hal/ports/STM32/LLD/I2Cv3/hal_i2c_lld.h
@@ -522,6 +522,7 @@ extern "C" {
   void i2c_lld_init(void);
   void i2c_lld_start(I2CDriver *i2cp);
   void i2c_lld_stop(I2CDriver *i2cp);
+  void i2c_lld_soft_stop(I2CDriver *i2cp);
   msg_t i2c_lld_master_transmit_timeout(I2CDriver *i2cp, i2caddr_t addr,
                                         const uint8_t *txbuf, size_t txbytes,
                                         uint8_t *rxbuf, size_t rxbytes,

--- a/os/hal/src/hal_i2c.c
+++ b/os/hal/src/hal_i2c.c
@@ -104,6 +104,29 @@ void i2cStart(I2CDriver *i2cp, const I2CConfig *config) {
 }
 
 /**
+ * @brief   Like i2cStop, but doesn't stop the clock nor disable the peripheral.
+ *
+ * @param[in] i2cp      pointer to the @p I2CDriver object
+ *
+ * @api
+ */
+void i2cSoftStop(I2CDriver *i2cp) {
+
+  osalDbgCheck(i2cp != NULL);
+
+  osalSysLock();
+
+  osalDbgAssert((i2cp->state == I2C_STOP) || (i2cp->state == I2C_READY) ||
+                (i2cp->state == I2C_LOCKED), "invalid state");
+
+  i2c_lld_soft_stop(i2cp);
+  i2cp->config = NULL;
+  i2cp->state  = I2C_STOP;
+
+  osalSysUnlock();
+}
+
+/**
  * @brief   Deactivates the I2C peripheral.
  *
  * @param[in] i2cp      pointer to the @p I2CDriver object


### PR DESCRIPTION
When we call i2cStop() we are aborting the current transfer,
disabling DMA, disabling interrupts and then cutting the clock to the
peripheral.

If i2cStop() is called after each transfer, for example to be able
to share DMA, this has the nasty consequence of breaking the stop
condition and NACK'ing on received bytes from a slave. This happens
because when the perifpheral didn't have time yet to complete the stop
condition and we just go ahead and disable everything

This provides a "soft stop" option, in which we disable DMA, disable
interrupts, but we keep the peripheral turned on: this is sufficient
for making sure the peripheral won't trigger any transaction due to
noise in the bus and that the DMA won't be used. This way stop
condition and acks work again when calling i2cSoftStop() after each
i2c transaction.