### PR TITLE
STM32: check for FIFO de-sync in SPIv2 and reset peripheral

### DIFF
--- a/os/hal/ports/STM32/LLD/SPIv1/hal_spi_lld.c
+++ b/os/hal/ports/STM32/LLD/SPIv1/hal_spi_lld.c
@@ -328,6 +328,7 @@ void spi_lld_start(SPIDriver *spip) {
                                     (stm32_dmaisr_t)spi_lld_serve_tx_interrupt,
                                     (void *)spip);
       osalDbgAssert(spip->dmatx != NULL, "unable to allocate stream");
+      rccResetSPI1();
       rccEnableSPI1(true);
     }
 #endif
@@ -343,6 +344,7 @@ void spi_lld_start(SPIDriver *spip) {
                                     (stm32_dmaisr_t)spi_lld_serve_tx_interrupt,
                                     (void *)spip);
       osalDbgAssert(spip->dmatx != NULL, "unable to allocate stream");
+      rccResetSPI2();
       rccEnableSPI2(true);
     }
 #endif
@@ -358,6 +360,7 @@ void spi_lld_start(SPIDriver *spip) {
                                     (stm32_dmaisr_t)spi_lld_serve_tx_interrupt,
                                     (void *)spip);
       osalDbgAssert(spip->dmatx != NULL, "unable to allocate stream");
+      rccResetSPI3();
       rccEnableSPI3(true);
     }
 #endif
@@ -373,6 +376,7 @@ void spi_lld_start(SPIDriver *spip) {
                                     (stm32_dmaisr_t)spi_lld_serve_tx_interrupt,
                                     (void *)spip);
       osalDbgAssert(spip->dmatx != NULL, "unable to allocate stream");
+      rccResetSPI4();
       rccEnableSPI4(true);
     }
 #endif
@@ -388,6 +392,7 @@ void spi_lld_start(SPIDriver *spip) {
                                     (stm32_dmaisr_t)spi_lld_serve_tx_interrupt,
                                     (void *)spip);
       osalDbgAssert(spip->dmatx != NULL, "unable to allocate stream");
+      rccResetSPI5();
       rccEnableSPI5(true);
     }
 #endif
@@ -403,6 +408,7 @@ void spi_lld_start(SPIDriver *spip) {
                                     (stm32_dmaisr_t)spi_lld_serve_tx_interrupt,
                                     (void *)spip);
       osalDbgAssert(spip->dmatx != NULL, "unable to allocate stream");
+      rccResetSPI6();
       rccEnableSPI6(true);
     }
 #endif

--- a/os/hal/ports/STM32/LLD/SPIv2/hal_spi_lld.c
+++ b/os/hal/ports/STM32/LLD/SPIv2/hal_spi_lld.c
@@ -329,6 +329,7 @@ void spi_lld_start(SPIDriver *spip) {
                                     (stm32_dmaisr_t)spi_lld_serve_tx_interrupt,
                                     (void *)spip);
       osalDbgAssert(spip->dmatx != NULL, "unable to allocate stream");
+      rccResetSPI1();
       rccEnableSPI1(true);
 #if STM32_DMA_SUPPORTS_DMAMUX
       dmaSetRequestSource(spip->dmarx, STM32_DMAMUX1_SPI1_RX);
@@ -348,6 +349,7 @@ void spi_lld_start(SPIDriver *spip) {
                                     (stm32_dmaisr_t)spi_lld_serve_tx_interrupt,
                                     (void *)spip);
       osalDbgAssert(spip->dmatx != NULL, "unable to allocate stream");
+      rccResetSPI2();
       rccEnableSPI2(true);
 #if STM32_DMA_SUPPORTS_DMAMUX
       dmaSetRequestSource(spip->dmarx, STM32_DMAMUX1_SPI2_RX);
@@ -367,6 +369,7 @@ void spi_lld_start(SPIDriver *spip) {
                                     (stm32_dmaisr_t)spi_lld_serve_tx_interrupt,
                                     (void *)spip);
       osalDbgAssert(spip->dmatx != NULL, "unable to allocate stream");
+      rccResetSPI3();
       rccEnableSPI3(true);
 #if STM32_DMA_SUPPORTS_DMAMUX
       dmaSetRequestSource(spip->dmarx, STM32_DMAMUX1_SPI3_RX);
@@ -386,6 +389,7 @@ void spi_lld_start(SPIDriver *spip) {
                                     (stm32_dmaisr_t)spi_lld_serve_tx_interrupt,
                                     (void *)spip);
       osalDbgAssert(spip->dmatx != NULL, "unable to allocate stream");
+      rccResetSPI4();
       rccEnableSPI4(true);
 #if STM32_DMA_SUPPORTS_DMAMUX
       dmaSetRequestSource(spip->dmarx, STM32_DMAMUX1_SPI4_RX);
@@ -405,6 +409,7 @@ void spi_lld_start(SPIDriver *spip) {
                                     (stm32_dmaisr_t)spi_lld_serve_tx_interrupt,
                                     (void *)spip);
       osalDbgAssert(spip->dmatx != NULL, "unable to allocate stream");
+      rccResetSPI5();
       rccEnableSPI5(true);
 #if STM32_DMA_SUPPORTS_DMAMUX
       dmaSetRequestSource(spip->dmarx, STM32_DMAMUX1_SPI5_RX);
@@ -424,6 +429,7 @@ void spi_lld_start(SPIDriver *spip) {
                                     (stm32_dmaisr_t)spi_lld_serve_tx_interrupt,
                                     (void *)spip);
       osalDbgAssert(spip->dmatx != NULL, "unable to allocate stream");
+      rccResetSPI6();
       rccEnableSPI6(true);
 #if STM32_DMA_SUPPORTS_DMAMUX
       dmaSetRequestSource(spip->dmarx, STM32_DMAMUX1_SPI6_RX);

--- a/os/hal/ports/STM32/LLD/SPIv3/hal_spi_lld.c
+++ b/os/hal/ports/STM32/LLD/SPIv3/hal_spi_lld.c
@@ -513,6 +513,7 @@ void spi_lld_start(SPIDriver *spip) {
                                      (stm32_dmaisr_t)spi_lld_serve_dma_tx_interrupt,
                                      (void *)spip);
       osalDbgAssert(spip->tx.dma!= NULL, "unable to allocate stream");
+      rccResetSPI1();
       rccEnableSPI1(true);
       dmaSetRequestSource(spip->rx.dma, STM32_DMAMUX1_SPI1_RX);
       dmaSetRequestSource(spip->tx.dma, STM32_DMAMUX1_SPI1_TX);
@@ -530,6 +531,7 @@ void spi_lld_start(SPIDriver *spip) {
                                      (stm32_dmaisr_t)spi_lld_serve_dma_tx_interrupt,
                                      (void *)spip);
       osalDbgAssert(spip->tx.dma!= NULL, "unable to allocate stream");
+      rccResetSPI2();
       rccEnableSPI2(true);
       dmaSetRequestSource(spip->rx.dma, STM32_DMAMUX1_SPI2_RX);
       dmaSetRequestSource(spip->tx.dma, STM32_DMAMUX1_SPI2_TX);
@@ -547,6 +549,7 @@ void spi_lld_start(SPIDriver *spip) {
                                      (stm32_dmaisr_t)spi_lld_serve_dma_tx_interrupt,
                                      (void *)spip);
       osalDbgAssert(spip->tx.dma!= NULL, "unable to allocate stream");
+      rccResetSPI3();
       rccEnableSPI3(true);
       dmaSetRequestSource(spip->rx.dma, STM32_DMAMUX1_SPI3_RX);
       dmaSetRequestSource(spip->tx.dma, STM32_DMAMUX1_SPI3_TX);
@@ -564,6 +567,7 @@ void spi_lld_start(SPIDriver *spip) {
                                      (stm32_dmaisr_t)spi_lld_serve_dma_tx_interrupt,
                                      (void *)spip);
       osalDbgAssert(spip->tx.dma!= NULL, "unable to allocate stream");
+      rccResetSPI4();
       rccEnableSPI4(true);
       dmaSetRequestSource(spip->rx.dma, STM32_DMAMUX1_SPI4_RX);
       dmaSetRequestSource(spip->tx.dma, STM32_DMAMUX1_SPI4_TX);
@@ -581,6 +585,7 @@ void spi_lld_start(SPIDriver *spip) {
                                      (stm32_dmaisr_t)spi_lld_serve_dma_tx_interrupt,
                                      (void *)spip);
       osalDbgAssert(spip->tx.dma!= NULL, "unable to allocate stream");
+      rccResetSPI5();
       rccEnableSPI5(true);
       dmaSetRequestSource(spip->rx.dma, STM32_DMAMUX1_SPI5_RX);
       dmaSetRequestSource(spip->tx.dma, STM32_DMAMUX1_SPI5_TX);
@@ -598,6 +603,7 @@ void spi_lld_start(SPIDriver *spip) {
                                       (stm32_dmaisr_t)spi_lld_serve_bdma_tx_interrupt,
                                       (void *)spip);
       osalDbgAssert(spip->tx.dma!= NULL, "unable to allocate stream");
+      rccResetSPI6();
       rccEnableSPI6(true);
       bdmaSetRequestSource(spip->rx.bdma, STM32_DMAMUX2_SPI6_RX);
       bdmaSetRequestSource(spip->tx.bdma, STM32_DMAMUX2_SPI6_TX);


### PR DESCRIPTION
an electrical glitch on a STM32F765xx can cause FIFO de-sync where
unexpected bytes appear in the receive FIFO. When that happens we
reset the peripheral completely using the RCC. Note that just draining
the bytes is not effective