### PR TITLE
STM32-I2C: added optional ISR limit per transaction

### DIFF
--- a/os/hal/include/hal_i2c.h
+++ b/os/hal/include/hal_i2c.h
@@ -49,6 +49,7 @@
                                                 reception.                  */
 #define I2C_TIMEOUT                0x20    /**< @brief Hardware timeout.    */
 #define I2C_SMB_ALERT              0x40    /**< @brief SMBus Alert.         */
+#define I2C_ISR_LIMIT              0x80    /**< @brief exceeded maximum ISR limit */
 /** @} */
 
 /*===========================================================================*/

--- a/os/hal/ports/STM32/LLD/I2Cv1/hal_i2c_lld.c
+++ b/os/hal/ports/STM32/LLD/I2Cv1/hal_i2c_lld.c
@@ -273,6 +273,35 @@ static void i2c_lld_set_opmode(I2CDriver *i2cp) {
   dp->CR1 = regCR1;
 }
 
+#ifdef STM32_I2C_ISR_LIMIT
+/**
+ * @brief reset I2C peripheral
+ *
+ * @param[in] i2cp      pointer to the @p I2CDriver object
+ *
+ * @notapi
+ */
+static void i2c_lld_reset(I2CDriver *i2cp) {
+#if STM32_I2C_USE_I2C1
+    if (&I2CD1 == i2cp) {
+      rccResetI2C1();
+    }
+#endif /* STM32_I2C_USE_I2C1 */
+
+#if STM32_I2C_USE_I2C2
+    if (&I2CD2 == i2cp) {
+      rccResetI2C2();
+    }
+#endif /* STM32_I2C_USE_I2C2 */
+
+#if STM32_I2C_USE_I2C3
+    if (&I2CD3 == i2cp) {
+      rccResetI2C3();
+    }
+#endif /* STM32_I2C_USE_I2C3 */
+}
+#endif // STM32_I2C_ISR_LIMIT
+
 /**
  * @brief   I2C shared ISR code.
  *
@@ -284,6 +313,19 @@ static void i2c_lld_serve_event_interrupt(I2CDriver *i2cp) {
   I2C_TypeDef *dp = i2cp->i2c;
   uint32_t regSR2 = dp->SR2;
   uint32_t event = dp->SR1;
+
+#ifdef STM32_I2C_ISR_LIMIT
+    if (i2cp->isr_count++ > i2cp->isr_limit) {
+        i2cp->errors |= I2C_ISR_LIMIT;
+        if (i2cp->dmatx)
+            dmaStreamDisable(i2cp->dmatx);
+        if (i2cp->dmarx)
+            dmaStreamDisable(i2cp->dmarx);
+        i2c_lld_reset(i2cp);
+        _i2c_wakeup_error_isr(i2cp);
+        return;
+    }
+#endif
 
   /* Interrupts are disabled just before dmaStreamEnable() because there
      is no need of interrupts until next transaction begin. All the work is
@@ -407,6 +449,15 @@ static void i2c_lld_serve_error_interrupt(I2CDriver *i2cp, uint16_t sr) {
       dmaStreamDisable(i2cp->dmatx);
   if (i2cp->dmarx)
       dmaStreamDisable(i2cp->dmarx);
+
+#ifdef STM32_I2C_ISR_LIMIT
+    if (i2cp->isr_count++ > i2cp->isr_limit) {
+        i2cp->errors |= I2C_ISR_LIMIT;
+        i2c_lld_reset(i2cp);
+        _i2c_wakeup_error_isr(i2cp);
+        return;
+    }
+#endif
 
   i2cp->errors = I2C_NO_ERROR;
 
@@ -807,6 +858,11 @@ msg_t i2c_lld_master_receive_timeout(I2CDriver *i2cp, i2caddr_t addr,
                                      sysinterval_t timeout) {
   I2C_TypeDef *dp = i2cp->i2c;
 
+#ifdef STM32_I2C_ISR_LIMIT
+  i2cp->isr_limit = rxbytes * STM32_I2C_ISR_LIMIT;
+  i2cp->isr_count = 0;
+#endif
+
 #if defined(STM32F1XX_I2C)
   osalDbgCheck(rxbytes > 1);
 #endif
@@ -875,6 +931,11 @@ msg_t i2c_lld_master_transmit_timeout(I2CDriver *i2cp, i2caddr_t addr,
 
 #if defined(STM32F1XX_I2C) && !defined(_ARDUPILOT_)
   osalDbgCheck((rxbytes == 0) || ((rxbytes > 1) && (rxbuf != NULL)));
+#endif
+
+#ifdef STM32_I2C_ISR_LIMIT
+  i2cp->isr_limit = (txbytes + rxbytes) * STM32_I2C_ISR_LIMIT;
+  i2cp->isr_count = 0;
 #endif
 
   /* Resetting error flags for this transfer.*/

--- a/os/hal/ports/STM32/LLD/I2Cv1/hal_i2c_lld.h
+++ b/os/hal/ports/STM32/LLD/I2Cv1/hal_i2c_lld.h
@@ -460,6 +460,18 @@ struct I2CDriver {
    * @brief     Pointer to the I2Cx registers block.
    */
   I2C_TypeDef               *i2c;
+
+#ifdef STM32_I2C_ISR_LIMIT
+  /**
+   * @brief count of interrupts since transfer start
+   */
+  uint32_t                  isr_count;
+
+  /**
+   * @brief limit of interrupts for this transfer
+   */
+  uint32_t                  isr_limit;
+#endif
 };
 
 /*===========================================================================*/

--- a/os/hal/ports/STM32/LLD/I2Cv2/hal_i2c_lld.c
+++ b/os/hal/ports/STM32/LLD/I2Cv2/hal_i2c_lld.c
@@ -223,6 +223,41 @@ static void i2c_lld_abort_operation(I2CDriver *i2cp) {
 #endif
 }
 
+#ifdef STM32_I2C_ISR_LIMIT
+/**
+ * @brief   reset I2C peripheral
+ *
+ * @param[in] i2cp      pointer to the @p I2CDriver object
+ *
+ * @notapi
+ */
+static void i2c_lld_reset(I2CDriver *i2cp) {
+#if STM32_I2C_USE_I2C1
+    if (&I2CD1 == i2cp) {
+      rccResetI2C1();
+    }
+#endif /* STM32_I2C_USE_I2C1 */
+
+#if STM32_I2C_USE_I2C2
+    if (&I2CD2 == i2cp) {
+      rccResetI2C2();
+    }
+#endif /* STM32_I2C_USE_I2C2 */
+
+#if STM32_I2C_USE_I2C3
+    if (&I2CD3 == i2cp) {
+      rccResetI2C3();
+    }
+#endif /* STM32_I2C_USE_I2C3 */
+
+#if STM32_I2C_USE_I2C4
+    if (&I2CD4 == i2cp) {
+      rccResetI2C4();
+    }
+#endif  /* STM32_I2C_USE_I2C4 */
+}
+#endif // STM32_I2C_ISR_LIMIT
+
 /**
  * @brief   I2C shared ISR code.
  *
@@ -392,6 +427,30 @@ static void i2c_lld_serve_error_interrupt(I2CDriver *i2cp, uint32_t isr) {
 /* Driver interrupt handlers.                                                */
 /*===========================================================================*/
 
+/**
+ * check if ISR count limit has been exceeded for the current
+ * opration. This check will prevent interrupt storms in case the
+ * peripheral is behaving badly enough to cause unexpected interrupts
+ * and normal interrupt acknowledgement doesn't work
+ */
+static bool i2c_lld_check_isr_limit(I2CDriver *i2cp) {
+#ifdef STM32_I2C_ISR_LIMIT
+    if (i2cp->isr_count++ > i2cp->isr_limit) {
+        i2cp->errors |= I2C_ISR_LIMIT;
+        i2c_lld_reset(i2cp);
+#if STM32_I2C_USE_DMA == TRUE
+        if (i2cp->dmatx)
+            dmaStreamDisable(i2cp->dmatx);
+        if (i2cp->dmarx)
+            dmaStreamDisable(i2cp->dmarx);
+#endif // STM32_I2C_USE_DMA
+        _i2c_wakeup_error_isr(i2cp);
+        return true;
+    }
+#endif // STM32_I2C_ISR_LIMIT
+    return false;
+}
+
 #if STM32_I2C_USE_I2C1 || defined(__DOXYGEN__)
 #if defined(STM32_I2C1_GLOBAL_HANDLER) || defined(__DOXYGEN__)
 /**
@@ -403,6 +462,11 @@ OSAL_IRQ_HANDLER(STM32_I2C1_GLOBAL_HANDLER) {
   uint32_t isr = I2CD1.i2c->ISR;
 
   OSAL_IRQ_PROLOGUE();
+
+  if (i2c_lld_check_isr_limit(&I2CD1)) {
+      OSAL_IRQ_EPILOGUE();
+      return;
+  }
 
   /* Clearing IRQ bits.*/
   I2CD1.i2c->ICR = isr;
@@ -421,6 +485,11 @@ OSAL_IRQ_HANDLER(STM32_I2C1_EVENT_HANDLER) {
 
   OSAL_IRQ_PROLOGUE();
 
+  if (i2c_lld_check_isr_limit(&I2CD1)) {
+      OSAL_IRQ_EPILOGUE();
+      return;
+  }
+
   /* Clearing IRQ bits.*/
   I2CD1.i2c->ICR = isr & I2C_INT_MASK;
 
@@ -433,6 +502,11 @@ OSAL_IRQ_HANDLER(STM32_I2C1_ERROR_HANDLER) {
   uint32_t isr = I2CD1.i2c->ISR;
 
   OSAL_IRQ_PROLOGUE();
+
+  if (i2c_lld_check_isr_limit(&I2CD1)) {
+      OSAL_IRQ_EPILOGUE();
+      return;
+  }
 
   /* Clearing IRQ bits.*/
   I2CD1.i2c->ICR = isr & I2C_ERROR_MASK;
@@ -459,6 +533,11 @@ OSAL_IRQ_HANDLER(STM32_I2C2_GLOBAL_HANDLER) {
 
   OSAL_IRQ_PROLOGUE();
 
+  if (i2c_lld_check_isr_limit(&I2CD2)) {
+      OSAL_IRQ_EPILOGUE();
+      return;
+  }
+
   /* Clearing IRQ bits.*/
   I2CD2.i2c->ICR = isr;
 
@@ -476,6 +555,11 @@ OSAL_IRQ_HANDLER(STM32_I2C2_EVENT_HANDLER) {
 
   OSAL_IRQ_PROLOGUE();
 
+  if (i2c_lld_check_isr_limit(&I2CD2)) {
+      OSAL_IRQ_EPILOGUE();
+      return;
+  }
+
   /* Clearing IRQ bits.*/
   I2CD2.i2c->ICR = isr & I2C_INT_MASK;
 
@@ -488,6 +572,11 @@ OSAL_IRQ_HANDLER(STM32_I2C2_ERROR_HANDLER) {
   uint32_t isr = I2CD2.i2c->ISR;
 
   OSAL_IRQ_PROLOGUE();
+
+  if (i2c_lld_check_isr_limit(&I2CD2)) {
+      OSAL_IRQ_EPILOGUE();
+      return;
+  }
 
   /* Clearing IRQ bits.*/
   I2CD2.i2c->ICR = isr & I2C_ERROR_MASK;
@@ -514,6 +603,11 @@ OSAL_IRQ_HANDLER(STM32_I2C3_GLOBAL_HANDLER) {
 
   OSAL_IRQ_PROLOGUE();
 
+  if (i2c_lld_check_isr_limit(&I2CD3)) {
+      OSAL_IRQ_EPILOGUE();
+      return;
+  }
+
   /* Clearing IRQ bits.*/
   I2CD3.i2c->ICR = isr;
 
@@ -531,6 +625,11 @@ OSAL_IRQ_HANDLER(STM32_I2C3_EVENT_HANDLER) {
 
   OSAL_IRQ_PROLOGUE();
 
+  if (i2c_lld_check_isr_limit(&I2CD3)) {
+      OSAL_IRQ_EPILOGUE();
+      return;
+  }
+
   /* Clearing IRQ bits.*/
   I2CD3.i2c->ICR = isr & I2C_INT_MASK;
 
@@ -543,6 +642,11 @@ OSAL_IRQ_HANDLER(STM32_I2C3_ERROR_HANDLER) {
   uint32_t isr = I2CD3.i2c->ISR;
 
   OSAL_IRQ_PROLOGUE();
+
+  if (i2c_lld_check_isr_limit(&I2CD3)) {
+      OSAL_IRQ_EPILOGUE();
+      return;
+  }
 
   /* Clearing IRQ bits.*/
   I2CD3.i2c->ICR = isr & I2C_ERROR_MASK;
@@ -569,6 +673,11 @@ OSAL_IRQ_HANDLER(STM32_I2C4_GLOBAL_HANDLER) {
 
   OSAL_IRQ_PROLOGUE();
 
+  if (i2c_lld_check_isr_limit(&I2CD4)) {
+      OSAL_IRQ_EPILOGUE();
+      return;
+  }
+
   /* Clearing IRQ bits.*/
   I2CD4.i2c->ICR = isr;
 
@@ -586,6 +695,11 @@ OSAL_IRQ_HANDLER(STM32_I2C4_EVENT_HANDLER) {
 
   OSAL_IRQ_PROLOGUE();
 
+  if (i2c_lld_check_isr_limit(&I2CD4)) {
+      OSAL_IRQ_EPILOGUE();
+      return;
+  }
+
   /* Clearing IRQ bits.*/
   I2CD4.i2c->ICR = isr & I2C_INT_MASK;
 
@@ -598,6 +712,11 @@ OSAL_IRQ_HANDLER(STM32_I2C4_ERROR_HANDLER) {
   uint32_t isr = I2CD4.i2c->ISR;
 
   OSAL_IRQ_PROLOGUE();
+
+  if (i2c_lld_check_isr_limit(&I2CD4)) {
+      OSAL_IRQ_EPILOGUE();
+      return;
+  }
 
   /* Clearing IRQ bits.*/
   I2CD4.i2c->ICR = isr & I2C_ERROR_MASK;
@@ -1041,6 +1160,11 @@ msg_t i2c_lld_master_receive_timeout(I2CDriver *i2cp, i2caddr_t addr,
   /* Releases the lock from high level driver.*/
   osalSysUnlock();
 
+#ifdef STM32_I2C_ISR_LIMIT
+  i2cp->isr_limit = rxbytes * STM32_I2C_ISR_LIMIT;
+  i2cp->isr_count = 0;
+#endif // STM32_I2C_ISR_LIMIT
+
 #if STM32_I2C_USE_DMA == TRUE
   /* RX DMA setup.*/
   dmaStreamSetMode(i2cp->dmarx, i2cp->rxdmamode);
@@ -1144,6 +1268,11 @@ msg_t i2c_lld_master_transmit_timeout(I2CDriver *i2cp, i2caddr_t addr,
   /* Releases the lock from high level driver.*/
   osalSysUnlock();
 
+#ifdef STM32_I2C_ISR_LIMIT
+  i2cp->isr_limit = (txbytes + rxbytes) * STM32_I2C_ISR_LIMIT;
+  i2cp->isr_count = 0;
+#endif
+  
 #if STM32_I2C_USE_DMA == TRUE
   /* TX DMA setup.*/
   dmaStreamSetMode(i2cp->dmatx, i2cp->txdmamode);

--- a/os/hal/ports/STM32/LLD/I2Cv2/hal_i2c_lld.h
+++ b/os/hal/ports/STM32/LLD/I2Cv2/hal_i2c_lld.h
@@ -442,6 +442,18 @@ struct I2CDriver {
    * @brief     Pointer to the I2Cx registers block.
    */
   I2C_TypeDef               *i2c;
+
+#ifdef STM32_I2C_ISR_LIMIT
+  /**
+   * @brief count of interrupts since transfer start
+   */
+  uint32_t                  isr_count;
+
+  /**
+   * @brief limit of interrupts for this transfer
+   */
+  uint32_t                  isr_limit;
+#endif
 };
 
 /*===========================================================================*/

--- a/os/hal/ports/STM32/LLD/I2Cv3/hal_i2c_lld.c
+++ b/os/hal/ports/STM32/LLD/I2Cv3/hal_i2c_lld.c
@@ -466,6 +466,61 @@ static void i2c_lld_serve_error_interrupt(I2CDriver *i2cp, uint32_t isr) {
 /* Driver interrupt handlers.                                                */
 /*===========================================================================*/
 
+#ifdef STM32_I2C_ISR_LIMIT
+/**
+ * @brief   reset i2c peripheral
+ *
+ * @param[in] i2cp      pointer to the @p I2CDriver object
+ *
+ * @notapi
+ */
+static void i2c_lld_reset(I2CDriver *i2cp) {
+#if STM32_I2C_USE_I2C1
+    if (&I2CD1 == i2cp) {
+      rccResetI2C1();
+    }
+#endif /* STM32_I2C_USE_I2C1 */
+
+#if STM32_I2C_USE_I2C2
+    if (&I2CD2 == i2cp) {
+      rccResetI2C2();
+    }
+#endif /* STM32_I2C_USE_I2C2 */
+
+#if STM32_I2C_USE_I2C3
+    if (&I2CD3 == i2cp) {
+      rccResetI2C3();
+    }
+#endif /* STM32_I2C_USE_I2C3 */
+
+#if STM32_I2C_USE_I2C4
+    if (&I2CD4 == i2cp) {
+      rccResetI2C4();
+    }
+#endif /* STM32_I2C_USE_I2C4 */
+}
+#endif // STM32_I2C_ISR_LIMIT
+
+/**
+ * check if ISR count limit has been exceeded for the current
+ * opration. This check will prevent interrupt storms in case the
+ * peripheral is behaving badly enough to cause unexpected interrupts
+ * and normal interrupt acknowledgement doesn't work
+ */
+static bool i2c_lld_check_isr_limit(I2CDriver *i2cp) {
+#ifdef STM32_I2C_ISR_LIMIT
+    if (i2cp->isr_count++ > i2cp->isr_limit) {
+        i2cp->errors |= I2C_ISR_LIMIT;
+        i2c_lld_reset(i2cp);
+        i2c_lld_stop_rx_dma(i2cp);
+        i2c_lld_stop_tx_dma(i2cp);
+        _i2c_wakeup_error_isr(i2cp);
+        return true;
+    }
+#endif // STM32_I2C_ISR_LIMIT
+    return false;
+}
+
 #if STM32_I2C_USE_I2C1 || defined(__DOXYGEN__)
 #if defined(STM32_I2C1_GLOBAL_HANDLER) || defined(__DOXYGEN__)
 /**
@@ -477,6 +532,11 @@ OSAL_IRQ_HANDLER(STM32_I2C1_GLOBAL_HANDLER) {
   uint32_t isr = I2CD1.i2c->ISR;
 
   OSAL_IRQ_PROLOGUE();
+
+  if (i2c_lld_check_isr_limit(&I2CD1)) {
+      OSAL_IRQ_EPILOGUE();
+      return;
+  }
 
   /* Clearing IRQ bits.*/
   I2CD1.i2c->ICR = isr;
@@ -495,6 +555,11 @@ OSAL_IRQ_HANDLER(STM32_I2C1_EVENT_HANDLER) {
 
   OSAL_IRQ_PROLOGUE();
 
+  if (i2c_lld_check_isr_limit(&I2CD1)) {
+      OSAL_IRQ_EPILOGUE();
+      return;
+  }
+
   /* Clearing IRQ bits.*/
   I2CD1.i2c->ICR = isr & I2C_INT_MASK;
 
@@ -507,6 +572,11 @@ OSAL_IRQ_HANDLER(STM32_I2C1_ERROR_HANDLER) {
   uint32_t isr = I2CD1.i2c->ISR;
 
   OSAL_IRQ_PROLOGUE();
+
+  if (i2c_lld_check_isr_limit(&I2CD1)) {
+      OSAL_IRQ_EPILOGUE();
+      return;
+  }
 
   /* Clearing IRQ bits.*/
   I2CD1.i2c->ICR = isr & I2C_ERROR_MASK;
@@ -533,6 +603,11 @@ OSAL_IRQ_HANDLER(STM32_I2C2_GLOBAL_HANDLER) {
 
   OSAL_IRQ_PROLOGUE();
 
+  if (i2c_lld_check_isr_limit(&I2CD2)) {
+      OSAL_IRQ_EPILOGUE();
+      return;
+  }
+
   /* Clearing IRQ bits.*/
   I2CD2.i2c->ICR = isr;
 
@@ -550,6 +625,11 @@ OSAL_IRQ_HANDLER(STM32_I2C2_EVENT_HANDLER) {
 
   OSAL_IRQ_PROLOGUE();
 
+  if (i2c_lld_check_isr_limit(&I2CD2)) {
+      OSAL_IRQ_EPILOGUE();
+      return;
+  }
+
   /* Clearing IRQ bits.*/
   I2CD2.i2c->ICR = isr & I2C_INT_MASK;
 
@@ -562,6 +642,11 @@ OSAL_IRQ_HANDLER(STM32_I2C2_ERROR_HANDLER) {
   uint32_t isr = I2CD2.i2c->ISR;
 
   OSAL_IRQ_PROLOGUE();
+
+  if (i2c_lld_check_isr_limit(&I2CD2)) {
+      OSAL_IRQ_EPILOGUE();
+      return;
+  }
 
   /* Clearing IRQ bits.*/
   I2CD2.i2c->ICR = isr & I2C_ERROR_MASK;
@@ -588,6 +673,11 @@ OSAL_IRQ_HANDLER(STM32_I2C3_GLOBAL_HANDLER) {
 
   OSAL_IRQ_PROLOGUE();
 
+  if (i2c_lld_check_isr_limit(&I2CD3)) {
+      OSAL_IRQ_EPILOGUE();
+      return;
+  }
+
   /* Clearing IRQ bits.*/
   I2CD3.i2c->ICR = isr;
 
@@ -605,6 +695,11 @@ OSAL_IRQ_HANDLER(STM32_I2C3_EVENT_HANDLER) {
 
   OSAL_IRQ_PROLOGUE();
 
+  if (i2c_lld_check_isr_limit(&I2CD3)) {
+      OSAL_IRQ_EPILOGUE();
+      return;
+  }
+
   /* Clearing IRQ bits.*/
   I2CD3.i2c->ICR = isr & I2C_INT_MASK;
 
@@ -617,6 +712,11 @@ OSAL_IRQ_HANDLER(STM32_I2C3_ERROR_HANDLER) {
   uint32_t isr = I2CD3.i2c->ISR;
 
   OSAL_IRQ_PROLOGUE();
+
+  if (i2c_lld_check_isr_limit(&I2CD3)) {
+      OSAL_IRQ_EPILOGUE();
+      return;
+  }
 
   /* Clearing IRQ bits.*/
   I2CD3.i2c->ICR = isr & I2C_ERROR_MASK;
@@ -643,6 +743,11 @@ OSAL_IRQ_HANDLER(STM32_I2C4_GLOBAL_HANDLER) {
 
   OSAL_IRQ_PROLOGUE();
 
+  if (i2c_lld_check_isr_limit(&I2CD4)) {
+      OSAL_IRQ_EPILOGUE();
+      return;
+  }
+
   /* Clearing IRQ bits.*/
   I2CD4.i2c->ICR = isr;
 
@@ -660,6 +765,11 @@ OSAL_IRQ_HANDLER(STM32_I2C4_EVENT_HANDLER) {
 
   OSAL_IRQ_PROLOGUE();
 
+  if (i2c_lld_check_isr_limit(&I2CD4)) {
+      OSAL_IRQ_EPILOGUE();
+      return;
+  }
+
   /* Clearing IRQ bits.*/
   I2CD4.i2c->ICR = isr & I2C_INT_MASK;
 
@@ -672,6 +782,11 @@ OSAL_IRQ_HANDLER(STM32_I2C4_ERROR_HANDLER) {
   uint32_t isr = I2CD4.i2c->ISR;
 
   OSAL_IRQ_PROLOGUE();
+
+  if (i2c_lld_check_isr_limit(&I2CD4)) {
+      OSAL_IRQ_EPILOGUE();
+      return;
+  }
 
   /* Clearing IRQ bits.*/
   I2CD4.i2c->ICR = isr & I2C_ERROR_MASK;
@@ -1100,6 +1215,11 @@ msg_t i2c_lld_master_receive_timeout(I2CDriver *i2cp, i2caddr_t addr,
   /* Releases the lock from high level driver.*/
   osalSysUnlock();
 
+#ifdef STM32_I2C_ISR_LIMIT
+  i2cp->isr_limit = rxbytes * STM32_I2C_ISR_LIMIT;
+  i2cp->isr_count = 0;
+#endif // STM32_I2C_ISR_LIMIT
+  
   /* Sizes of transfer phases.*/
   i2cp->txbytes = 0U;
   i2cp->rxbytes = rxbytes;
@@ -1223,6 +1343,11 @@ msg_t i2c_lld_master_transmit_timeout(I2CDriver *i2cp, i2caddr_t addr,
   /* Releases the lock from high level driver.*/
   osalSysUnlock();
 
+#ifdef STM32_I2C_ISR_LIMIT
+  i2cp->isr_limit = (txbytes + rxbytes) * STM32_I2C_ISR_LIMIT;
+  i2cp->isr_count = 0;
+#endif // STM32_I2C_ISR_LIMIT
+  
   /* Sizes of transfer phases.*/
   i2cp->txbytes = txbytes;
   i2cp->rxbytes = rxbytes;

--- a/os/hal/ports/STM32/LLD/I2Cv3/hal_i2c_lld.h
+++ b/os/hal/ports/STM32/LLD/I2Cv3/hal_i2c_lld.h
@@ -478,6 +478,18 @@ struct I2CDriver {
    * @brief     Pointer to the I2Cx registers block.
    */
   I2C_TypeDef               *i2c;
+
+#ifdef STM32_I2C_ISR_LIMIT
+  /**
+   * @brief count of interrupts since transfer start
+   */
+  uint32_t                  isr_count;
+
+  /**
+   * @brief limit of interrupts for this transfer
+   */
+  uint32_t                  isr_limit;
+#endif
 };
 
 /*===========================================================================*/


### PR DESCRIPTION
this adds a limit on the number of interrupts allowed per transaction
for I2C peripherals on STM32. It is meant to prevent any possibility
of an interrupt storm due to a badly behaving peripheral which
generates an interrupt which isn't properly acknowledged or cannot be
acknowledged