### PR TITLE
TIMv1: removed restriction on clock setting for pwm driver

### DIFF
--- a/os/hal/ports/STM32/LLD/TIMv1/hal_pwm_lld.c
+++ b/os/hal/ports/STM32/LLD/TIMv1/hal_pwm_lld.c
@@ -705,9 +705,7 @@ void pwm_lld_start(PWMDriver *pwmp) {
 
   /* Timer configuration.*/
   psc = (pwmp->clock / pwmp->config->frequency) - 1;
-  osalDbgAssert((psc <= 0xFFFF) &&
-                ((psc + 1) * pwmp->config->frequency) == pwmp->clock,
-                "invalid frequency");
+  osalDbgAssert(psc <= 0xFFFF, "invalid frequency");
   pwmp->tim->PSC  = psc;
   pwmp->tim->ARR  = pwmp->period - 1;
   pwmp->tim->CR2  = pwmp->config->cr2;


### PR DESCRIPTION
this restriction is not needed, and results in timing choices which
don't produce the best match for a desired bit rate