### PR TITLE
Fatfs: Fall through for clarification.

### DIFF
--- a/ext/fatfs/src/ff.c
+++ b/ext/fatfs/src/ff.c
@@ -1038,6 +1038,7 @@ DWORD get_fat (		/* 0xFFFFFFFF:Disk error, 1:Internal error, 2..0x7FFFFFFF:Clust
 			}
 			/* go to default */
 #endif
+            /* fall through */
 		default:
 			val = 1;	/* Internal error */
 		}


### PR DESCRIPTION
I built a Copter and got a "fall through" warning.
I think it's a good idea to build a Copter and have 0 WARNING cases.
I've addressed this warning.