### PR TITLE
Allow osalDbgAssert to be redefined

### DIFF
--- a/os/hal/osal/rt/osal.h
+++ b/os/hal/osal/rt/osal.h
@@ -256,7 +256,9 @@ typedef struct {
  *
  * @api
  */
+#ifndef osalDbgAssert
 #define osalDbgAssert(c, remark) chDbgAssert(c, remark)
+#endif
 
 /**
  * @brief   Function parameters check.


### PR DESCRIPTION
This is required so that we use print assertion failure messages to a GPIO pin