### PR TITLE
STM32H7xx: add ability to mark SRAM4 as NOCACHE

### DIFF
--- a/os/hal/ports/STM32/STM32H7xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32H7xx/hal_lld.c
@@ -167,8 +167,9 @@ void hal_lld_init(void) {
   irqInit();
 
   /* MPU initialization.*/
-#if (STM32_NOCACHE_SRAM1_SRAM2 == TRUE) || (STM32_NOCACHE_SRAM3 == TRUE)
+#if (STM32_NOCACHE_SRAM1_SRAM2 == TRUE) || (STM32_NOCACHE_SRAM3 == TRUE) || (STM32_NOCACHE_SRAM4 == TRUE)
   {
+#if (STM32_NOCACHE_SRAM1_SRAM2 == TRUE) || (STM32_NOCACHE_SRAM3 == TRUE)
     uint32_t base, size;
 
 #if (STM32_NOCACHE_SRAM1_SRAM2 == TRUE) && (STM32_NOCACHE_SRAM3 == TRUE)
@@ -192,6 +193,15 @@ void hal_lld_init(void) {
                        MPU_RASR_ATTR_NON_CACHEABLE |
                        size |
                        MPU_RASR_ENABLE);
+#endif
+#if (STM32_NOCACHE_SRAM4 == TRUE)
+    mpuConfigureRegion(STM32_NOCACHE_SRAM4_MPU_REGION,
+                       0x38000000U,
+                       MPU_RASR_ATTR_AP_RW_RW |
+                       MPU_RASR_ATTR_NON_CACHEABLE |
+                       MPU_RASR_SIZE_64K |
+                       MPU_RASR_ENABLE);
+#endif
     mpuEnable(MPU_CTRL_PRIVDEFENA);
 
     /* Invalidating data cache to make sure that the MPU settings are taken

--- a/os/hal/ports/STM32/STM32H7xx/hal_lld.h
+++ b/os/hal/ports/STM32/STM32H7xx/hal_lld.h
@@ -631,6 +631,21 @@
 #endif
 
 /**
+ * @brief   MPU region to be used for no-cache SRAM4 area.
+ */
+#if !defined(STM32_NOCACHE_SRAM4_MPU_REGION) || defined(__DOXYGEN__)
+#define STM32_NOCACHE_SRAM4_MPU_REGION      MPU_REGION_5
+#endif
+
+/**
+ * @brief   Add no-cache attribute to SRAM4.
+ * @note    MPU region STM32_NOCACHE_SRAM4_MPU_REGION is used if enabled.
+ */
+#if !defined(STM32_NOCACHE_SRAM4) || defined(__DOXYGEN__)
+#define STM32_NOCACHE_SRAM4                 FALSE
+#endif
+
+/**
  * @brief   PWR CR1 initializer.
  */
 #if !defined(STM32_PWR_CR1) || defined(__DOXYGEN__)


### PR DESCRIPTION
I will preface this with the fact that I have no idea what I'm doing with this stuff, but I Googled it and found a patch from Equinox of the ChibiOS fourm, https://forum.chibios.org/viewtopic.php?f=38&t=5790#p39590. This is that, I have no idea if it is correct.  

The goal being to allow to expand the available DMA memory so we can flash more LEDs at once. (https://github.com/ArduPilot/ardupilot/pull/16958)

I'm not sure where we should be using the new `STM32_NOCACHE_SRAM4` define this adds.