### PR TITLE
fatfs: halt loop as index hits 0

### DIFF
--- a/ext/fatfs/source/ff.c
+++ b/ext/fatfs/source/ff.c
@@ -2044,7 +2044,7 @@ static void gen_numname (
 		if (c > '9') c += 7;
 		ns[i--] = c;
 		seq /= 16;
-	} while (seq);
+	} while (i && seq);
 	ns[i] = '~';
 
 	/* Append the number to the SFN body */


### PR DESCRIPTION
This solves the issue of builds breaking with -O3