### PR TITLE
ff: lower MAX_MALLOC to 2048

### DIFF
--- a/ext/fatfs/source/ff.c
+++ b/ext/fatfs/source/ff.c
@@ -542,7 +542,7 @@ static WCHAR LfnBuf[FF_MAX_LFN + 1];		/* LFN working buffer */
 #define FREE_NAMBUF()	ff_memfree(lfn)
 #endif
 #define LEAVE_MKFS(res)	{ if (!work) ff_memfree(buf); return res; }
-#define MAX_MALLOC	0x8000	/* Must be >=FF_MAX_SS */
+#define MAX_MALLOC	2048	/* Must be >=FF_MAX_SS */
 
 #else
 #error Wrong setting of FF_USE_LFN


### PR DESCRIPTION
the old value exceeded the maximum DMA allocation on some boards, and
was the underlying cause of the mkdir failure on Pixhawk1