### PR TITLE
Fix ADC Dual mode operation

### DIFF
--- a/os/hal/ports/STM32/LLD/ADCv4/hal_adc_lld.c
+++ b/os/hal/ports/STM32/LLD/ADCv4/hal_adc_lld.c
@@ -428,13 +428,11 @@ void adc_lld_init(void) {
 #if STM32_ADC_USE_ADC12 == TRUE
   rccEnableADC12(true);
   rccResetADC12();
-  ADC12_COMMON->CCR = STM32_ADC_ADC12_CLOCK_MODE | ADC_DMA_DAMDF | ADC12_CCR_DUAL;
   rccDisableADC12();
 #endif
 #if STM32_ADC_USE_ADC3 == TRUE
   rccEnableADC3(true);
   rccResetADC3();
-  ADC3_COMMON->CCR = STM32_ADC_ADC3_CLOCK_MODE;
   rccDisableADC3();
 #endif
 #endif
@@ -469,6 +467,7 @@ msg_t adc_lld_start(ADCDriver *adcp) {
 
       rccEnableADC12(true);
       rccResetADC12();
+      ADC12_COMMON->CCR = STM32_ADC_ADC12_CLOCK_MODE | ADC_DMA_DAMDF | ADC12_CCR_DUAL;
 
       dmaSetRequestSource(adcp->data.dma, STM32_DMAMUX1_ADC1);
 
@@ -501,6 +500,7 @@ msg_t adc_lld_start(ADCDriver *adcp) {
 
       rccEnableADC3(true);
       rccResetADC3();
+      ADC3_COMMON->CCR = STM32_ADC_ADC3_CLOCK_MODE;
 
       bdmaSetRequestSource(adcp->data.bdma, STM32_DMAMUX2_ADC3_REQ);
 
@@ -564,9 +564,6 @@ void adc_lld_stop(ADCDriver *adcp) {
       /* Releasing the associated DMA channel.*/
       dmaStreamFreeI(adcp->data.dma);
       adcp->data.dma = NULL;
-
-      /* Resetting CCR options except default ones.*/
-      adcp->adcc->CCR = STM32_ADC_ADC12_CLOCK_MODE | ADC_DMA_DAMDF | ADC12_CCR_DUAL;
       rccDisableADC12();
     }
 #endif
@@ -577,9 +574,6 @@ void adc_lld_stop(ADCDriver *adcp) {
       /* Releasing the associated BDMA channel.*/
       bdmaStreamFreeI(adcp->data.bdma);
       adcp->data.bdma = NULL;
-
-      /* Resetting CCR options except default ones.*/
-      adcp->adcc->CCR = STM32_ADC_ADC3_CLOCK_MODE;
       rccDisableADC3();
     }
 #endif


### PR DESCRIPTION
There is an addition of RCC reset for ADC, which causes default CCR settings to reset.