### PR TITLE
Fixes for assertion fails

### DIFF
--- a/os/hal/ports/STM32/LLD/TIMv1/hal_pwm_lld.c
+++ b/os/hal/ports/STM32/LLD/TIMv1/hal_pwm_lld.c
@@ -870,8 +870,7 @@ void pwm_lld_start(PWMDriver *pwmp) {
 
   /* Timer configuration.*/
   psc = (pwmp->clock / pwmp->config->frequency) - 1;
-  osalDbgAssert((psc <= 0xFFFF) &&
-                ((psc + 1) * pwmp->config->frequency) == pwmp->clock,
+  osalDbgAssert((psc <= 0xFFFF),
                 "invalid frequency");
   pwmp->tim->PSC  = psc;
   pwmp->tim->ARR  = pwmp->period - 1;

--- a/os/hal/ports/STM32/STM32H7xx/stm32_registry.h
+++ b/os/hal/ports/STM32/STM32H7xx/stm32_registry.h
@@ -41,10 +41,14 @@
     defined(STM32H7A3xx)  || defined(STM32H7B3xx)  ||                       \
     defined(STM32H7A3xxQ) || defined(STM32H7B3xxQ)
 #define STM32_HAS_M7                        TRUE
+#ifndef STM32_HAS_M4
 #define STM32_HAS_M4                        FALSE
+#endif
 #else
 #define STM32_HAS_M7                        TRUE
+#ifndef STM32_HAS_M4
 #define STM32_HAS_M4                        TRUE
+#endif
 #endif
 
 /*===========================================================================*/


### PR DESCRIPTION
* This resolves assertion detected while running on H7, ability to disable knowledge of M4 chips is needed for now, as we do clock resets before enabling them, there's no support for running on M4 right now anyways so ignoring the checks is just the best way for now.
* Other assert I hit is with NeoPixel setup where we don't get whole number out of target frequency and Timer clock. 