### PR TITLE
TIMv1: missing EICU ISRs

### DIFF
--- a/os/hal/ports/STM32/LLD/TIMv1/hal_eicu_lld.c
+++ b/os/hal/ports/STM32/LLD/TIMv1/hal_eicu_lld.c
@@ -266,6 +266,7 @@ static void start_channels(EICUDriver *eicup) {
 /*===========================================================================*/
 
 #if STM32_EICU_USE_TIM1
+#if !defined(STM32_TIM1_SUPPRESS_ISR)
 #if !defined(STM32_TIM1_UP_HANDLER)
 #error "STM32_TIM1_UP_HANDLER not defined"
 #endif
@@ -305,10 +306,11 @@ OSAL_IRQ_HANDLER(STM32_TIM1_CC_HANDLER) {
 
   OSAL_IRQ_EPILOGUE();
 }
+#endif /* !defined(STM32_TIM1_SUPPRESS_ISR) */
 #endif /* STM32_EICU_USE_TIM1 */
 
 #if STM32_EICU_USE_TIM2
-
+#if !defined(STM32_TIM2_SUPPRESS_ISR)
 #if !defined(STM32_TIM2_HANDLER)
 #error "STM32_TIM2_HANDLER not defined"
 #endif
@@ -328,9 +330,11 @@ OSAL_IRQ_HANDLER(STM32_TIM2_HANDLER) {
 
   OSAL_IRQ_EPILOGUE();
 }
+#endif /* !defined(STM32_TIM2_SUPPRESS_ISR) */
 #endif /* STM32_EICU_USE_TIM2 */
 
 #if STM32_EICU_USE_TIM3
+#if !defined(STM32_TIM3_SUPPRESS_ISR)
 #if !defined(STM32_TIM3_HANDLER)
 #error "STM32_TIM3_HANDLER not defined"
 #endif
@@ -350,9 +354,11 @@ OSAL_IRQ_HANDLER(STM32_TIM3_HANDLER) {
 
   OSAL_IRQ_EPILOGUE();
 }
+#endif /* !defined(STM32_TIM3_SUPPRESS_ISR) */
 #endif /* STM32_EICU_USE_TIM3 */
 
 #if STM32_EICU_USE_TIM4
+#if !defined(STM32_TIM4_SUPPRESS_ISR)
 #if !defined(STM32_TIM4_HANDLER)
 #error "STM32_TIM4_HANDLER not defined"
 #endif
@@ -372,9 +378,11 @@ OSAL_IRQ_HANDLER(STM32_TIM4_HANDLER) {
 
   OSAL_IRQ_EPILOGUE();
 }
+#endif /* !defined(STM32_TIM4_SUPPRESS_ISR) */
 #endif /* STM32_EICU_USE_TIM4 */
 
 #if STM32_EICU_USE_TIM5
+#if !defined(STM32_TIM5_SUPPRESS_ISR)
 #if !defined(STM32_TIM5_HANDLER)
 #error "STM32_TIM5_HANDLER not defined"
 #endif
@@ -394,9 +402,11 @@ OSAL_IRQ_HANDLER(STM32_TIM5_HANDLER) {
 
   OSAL_IRQ_EPILOGUE();
 }
+#endif /* !defined(STM32_TIM5_SUPPRESS_ISR) */
 #endif /* STM32_EICU_USE_TIM5 */
 
 #if STM32_EICU_USE_TIM8
+#if !defined(STM32_TIM8_SUPPRESS_ISR)
 #if !defined(STM32_TIM8_UP_HANDLER) && defined(STM32_TIM8_UP_TIM13_HANDLER)
 #define STM32_TIM8_UP_HANDLER STM32_TIM8_UP_TIM13_HANDLER
 #define STM32_TIM8_UP_NUMBER STM32_TIM8_UP_TIM13_NUMBER
@@ -440,116 +450,43 @@ OSAL_IRQ_HANDLER(STM32_TIM8_CC_HANDLER) {
 
   OSAL_IRQ_EPILOGUE();
 }
+#endif /* !defined(STM32_TIM8_SUPPRESS_ISR) */
 #endif /* STM32_EICU_USE_TIM8 */
 
-#if STM32_EICU_USE_TIM12
-#if !defined(STM32_TIM12_HANDLER)
-#error "STM32_TIM12_HANDLER not defined"
-#endif
-/**
- * @brief   TIM12 interrupt handler.
- * @note    It is assumed that the various sources are only activated if the
- *          associated callback pointer is not equal to @p NULL in order to not
- *          perform an extra check in a potentially critical interrupt handler.
- *
- * @isr
- */
-OSAL_IRQ_HANDLER(STM32_TIM12_HANDLER) {
+#if STM32_EICU_USE_TIM9 || defined(__DOXYGEN__)
+#if !defined(STM32_TIM9_SUPPRESS_ISR)
+#error "TIM9 ISR not defined by platform"
+#endif /* !defined(STM32_TIM9_SUPPRESS_ISR) */
+#endif /* STM32_EICU_USE_TIM9 */
 
-  OSAL_IRQ_PROLOGUE();
-
-  eicu_lld_serve_interrupt(&EICUD12);
-
-  OSAL_IRQ_EPILOGUE();
-}
-#endif /* STM32_EICU_USE_TIM12 */
-
-#if STM32_EICU_USE_TIM10
-#if !defined(STM32_TIM10_HANDLER)
-#error "STM32_TIM10_HANDLER not defined"
-#endif
-/**
- * @brief   TIM10 interrupt handler.
- * @note    It is assumed that the various sources are only activated if the
- *          associated callback pointer is not equal to @p NULL in order to not
- *          perform an extra check in a potentially critical interrupt handler.
- *
- * @isr
- */
-OSAL_IRQ_HANDLER(STM32_TIM10_HANDLER) {
-
-  OSAL_IRQ_PROLOGUE();
-
-  eicu_lld_serve_interrupt(&EICUD10);
-
-  OSAL_IRQ_EPILOGUE();
-}
+#if STM32_EICU_USE_TIM10 || defined(__DOXYGEN__)
+#if !defined(STM32_TIM10_SUPPRESS_ISR)
+#error "TIM10 ISR not defined by platform"
+#endif /* !defined(STM32_TIM10_SUPPRESS_ISR) */
 #endif /* STM32_EICU_USE_TIM10 */
 
-#if STM32_EICU_USE_TIM11
-#if !defined(STM32_TIM11_HANDLER)
-#error "STM32_TIM11_HANDLER not defined"
-#endif
-/**
- * @brief   TIM11 interrupt handler.
- * @note    It is assumed that the various sources are only activated if the
- *          associated callback pointer is not equal to @p NULL in order to not
- *          perform an extra check in a potentially critical interrupt handler.
- *
- * @isr
- */
-OSAL_IRQ_HANDLER(STM32_TIM11_HANDLER) {
-
-  OSAL_IRQ_PROLOGUE();
-
-  eicu_lld_serve_interrupt(&EICUD11);
-
-  OSAL_IRQ_EPILOGUE();
-}
+#if STM32_EICU_USE_TIM11 || defined(__DOXYGEN__)
+#if !defined(STM32_TIM11_SUPPRESS_ISR)
+#error "TIM11 ISR not defined by platform"
+#endif /* !defined(STM32_TIM11_SUPPRESS_ISR) */
 #endif /* STM32_EICU_USE_TIM11 */
 
-#if STM32_EICU_USE_TIM13
-#if !defined(STM32_TIM13_HANDLER)
-#error "STM32_TIM13_HANDLER not defined"
-#endif
-/**
- * @brief   TIM13 interrupt handler.
- * @note    It is assumed that the various sources are only activated if the
- *          associated callback pointer is not equal to @p NULL in order to not
- *          perform an extra check in a potentially critical interrupt handler.
- *
- * @isr
- */
-OSAL_IRQ_HANDLER(STM32_TIM13_HANDLER) {
+#if STM32_EICU_USE_TIM12 || defined(__DOXYGEN__)
+#if !defined(STM32_TIM12_SUPPRESS_ISR)
+#error "TIM12 ISR not defined by platform"
+#endif /* !defined(STM32_TIM12_SUPPRESS_ISR) */
+#endif /* STM32_EICU_USE_TIM12 */
 
-  OSAL_IRQ_PROLOGUE();
-
-  eicu_lld_serve_interrupt(&EICUD13);
-
-  OSAL_IRQ_EPILOGUE();
-}
+#if STM32_EICU_USE_TIM13 || defined(__DOXYGEN__)
+#if !defined(STM32_TIM13_SUPPRESS_ISR)
+#error "TIM13 ISR not defined by platform"
+#endif /* !defined(STM32_TIM13_SUPPRESS_ISR) */
 #endif /* STM32_EICU_USE_TIM13 */
 
-#if STM32_EICU_USE_TIM14
-#if !defined(STM32_TIM14_HANDLER)
-#error "STM32_TIM14_HANDLER not defined"
-#endif
-/**
- * @brief   TIM14 interrupt handler.
- * @note    It is assumed that the various sources are only activated if the
- *          associated callback pointer is not equal to @p NULL in order to not
- *          perform an extra check in a potentially critical interrupt handler.
- *
- * @isr
- */
-OSAL_IRQ_HANDLER(STM32_TIM14_HANDLER) {
-
-  OSAL_IRQ_PROLOGUE();
-
-  eicu_lld_serve_interrupt(&EICUD14);
-
-  OSAL_IRQ_EPILOGUE();
-}
+#if STM32_EICU_USE_TIM14 || defined(__DOXYGEN__)
+#if !defined(STM32_TIM14_SUPPRESS_ISR)
+#error "TIM14 ISR not defined by platform"
+#endif /* !defined(STM32_TIM14_SUPPRESS_ISR) */
 #endif /* STM32_EICU_USE_TIM14 */
 
 /*===========================================================================*/
@@ -658,8 +595,10 @@ void eicu_lld_start(EICUDriver *eicup) {
     if (&EICUD1 == eicup) {
       rccEnableTIM1(FALSE);
       rccResetTIM1();
+#if !defined(STM32_TIM1_SUPPRESS_ISR)
       nvicEnableVector(STM32_TIM1_UP_NUMBER, STM32_EICU_TIM1_IRQ_PRIORITY);
       nvicEnableVector(STM32_TIM1_CC_NUMBER, STM32_EICU_TIM1_IRQ_PRIORITY);
+#endif
       eicup->channels = 4;
 #if defined(STM32_TIM1CLK)
       eicup->clock = STM32_TIM1CLK;
@@ -672,7 +611,9 @@ void eicu_lld_start(EICUDriver *eicup) {
     if (&EICUD2 == eicup) {
       rccEnableTIM2(FALSE);
       rccResetTIM2();
+#if !defined(STM32_TIM2_SUPPRESS_ISR)
       nvicEnableVector(STM32_TIM2_NUMBER, STM32_EICU_TIM2_IRQ_PRIORITY);
+#endif
       eicup->channels = 4;
       eicup->clock = STM32_TIMCLK1;
     }
@@ -681,7 +622,9 @@ void eicu_lld_start(EICUDriver *eicup) {
     if (&EICUD3 == eicup) {
       rccEnableTIM3(FALSE);
       rccResetTIM3();
+#if !defined(STM32_TIM3_SUPPRESS_ISR)
       nvicEnableVector(STM32_TIM3_NUMBER, STM32_EICU_TIM3_IRQ_PRIORITY);
+#endif
       eicup->channels = 4;
       eicup->clock = STM32_TIMCLK1;
     }
@@ -690,7 +633,9 @@ void eicu_lld_start(EICUDriver *eicup) {
     if (&EICUD4 == eicup) {
       rccEnableTIM4(FALSE);
       rccResetTIM4();
+#if !defined(STM32_TIM4_SUPPRESS_ISR)
       nvicEnableVector(STM32_TIM4_NUMBER, STM32_EICU_TIM4_IRQ_PRIORITY);
+#endif
       eicup->channels = 4;
       eicup->clock = STM32_TIMCLK1;
     }
@@ -699,7 +644,9 @@ void eicu_lld_start(EICUDriver *eicup) {
     if (&EICUD5 == eicup) {
       rccEnableTIM5(FALSE);
       rccResetTIM5();
+#if !defined(STM32_TIM5_SUPPRESS_ISR)
       nvicEnableVector(STM32_TIM5_NUMBER, STM32_EICU_TIM5_IRQ_PRIORITY);
+#endif
       eicup->channels = 4;
       eicup->clock = STM32_TIMCLK1;
     }
@@ -708,8 +655,10 @@ void eicu_lld_start(EICUDriver *eicup) {
     if (&EICUD8 == eicup) {
       rccEnableTIM8(FALSE);
       rccResetTIM8();
+#if !defined(STM32_TIM8_SUPPRESS_ISR)
       nvicEnableVector(STM32_TIM8_UP_NUMBER, STM32_EICU_TIM8_IRQ_PRIORITY);
       nvicEnableVector(STM32_TIM8_CC_NUMBER, STM32_EICU_TIM8_IRQ_PRIORITY);
+#endif
       eicup->channels = 4;
 #if defined(STM32_TIM8CLK)
       eicup->clock = STM32_TIM8CLK;
@@ -730,7 +679,6 @@ void eicu_lld_start(EICUDriver *eicup) {
     if (&EICUD12 == eicup) {
       rccEnableTIM12(FALSE);
       rccResetTIM12();
-      nvicEnableVector(STM32_TIM12_NUMBER, STM32_EICU_TIM12_IRQ_PRIORITY);
       eicup->channels = 2;
       eicup->clock = STM32_TIMCLK1;
     }
@@ -739,7 +687,6 @@ void eicu_lld_start(EICUDriver *eicup) {
     if (&EICUD10 == eicup) {
       rccEnableTIM10(FALSE);
       rccResetTIM10();
-      nvicEnableVector(STM32_TIM10_NUMBER, STM32_EICU_TIM10_IRQ_PRIORITY);
       eicup->channels = 1;
       eicup->clock = STM32_TIMCLK2;
     }
@@ -748,7 +695,6 @@ void eicu_lld_start(EICUDriver *eicup) {
     if (&EICUD11 == eicup) {
       rccEnableTIM11(FALSE);
       rccResetTIM11();
-      nvicEnableVector(STM32_TIM11_NUMBER, STM32_EICU_TIM11_IRQ_PRIORITY);
       eicup->channels = 1;
       eicup->clock = STM32_TIMCLK2;
     }
@@ -757,7 +703,6 @@ void eicu_lld_start(EICUDriver *eicup) {
     if (&EICUD13 == eicup) {
       rccEnableTIM13(FALSE);
       rccResetTIM13();
-      nvicEnableVector(STM32_TIM13_NUMBER, STM32_EICU_TIM13_IRQ_PRIORITY);
       eicup->channels = 1;
       eicup->clock = STM32_TIMCLK1;
     }
@@ -766,7 +711,6 @@ void eicu_lld_start(EICUDriver *eicup) {
     if (&EICUD14 == eicup) {
       rccEnableTIM14(FALSE);
       rccResetTIM14();
-      nvicEnableVector(STM32_TIM14_NUMBER, STM32_EICU_TIM14_IRQ_PRIORITY);
       eicup->channels = 1;
       eicup->clock = STM32_TIMCLK1;
     }
@@ -850,39 +794,51 @@ void eicu_lld_stop(EICUDriver *eicup) {
 
 #if STM32_EICU_USE_TIM1
     if (&EICUD1 == eicup) {
+#if !defined(STM32_TIM1_SUPPRESS_ISR)
       nvicDisableVector(STM32_TIM1_UP_NUMBER);
+#endif
       nvicDisableVector(STM32_TIM1_CC_NUMBER);
       rccDisableTIM1();
     }
 #endif
 #if STM32_EICU_USE_TIM2
     if (&EICUD2 == eicup) {
+#if !defined(STM32_TIM2_SUPPRESS_ISR)
       nvicDisableVector(STM32_TIM2_NUMBER);
+#endif
       rccDisableTIM2();
     }
 #endif
 #if STM32_EICU_USE_TIM3
     if (&EICUD3 == eicup) {
+#if !defined(STM32_TIM3_SUPPRESS_ISR)
       nvicDisableVector(STM32_TIM3_NUMBER);
+#endif
       rccDisableTIM3();
     }
 #endif
 #if STM32_EICU_USE_TIM4
     if (&EICUD4 == eicup) {
+#if !defined(STM32_TIM4_SUPPRESS_ISR)
       nvicDisableVector(STM32_TIM4_NUMBER);
+#endif
       rccDisableTIM4();
     }
 #endif
 #if STM32_EICU_USE_TIM5
     if (&EICUD5 == eicup) {
+#if !defined(STM32_TIM5_SUPPRESS_ISR)
       nvicDisableVector(STM32_TIM5_NUMBER);
+#endif
       rccDisableTIM5();
     }
 #endif
 #if STM32_EICU_USE_TIM8
     if (&EICUD8 == eicup) {
+#if !defined(STM32_TIM8_SUPPRESS_ISR)
       nvicDisableVector(STM32_TIM8_UP_NUMBER);
       nvicDisableVector(STM32_TIM8_CC_NUMBER);
+#endif
       rccDisableTIM8();
     }
 #endif
@@ -893,32 +849,27 @@ void eicu_lld_stop(EICUDriver *eicup) {
 #endif
 #if STM32_EICU_USE_TIM12
     if (&EICUD12 == eicup) {
-      nvicDisableVector(STM32_TIM12_NUMBER);
       rccDisableTIM12();
     }
 #endif
   }
 #if STM32_EICU_USE_TIM10
     if (&EICUD10 == eicup) {
-      nvicDisableVector(STM32_TIM10_NUMBER);
       rccDisableTIM10();
     }
 #endif
 #if STM32_EICU_USE_TIM11
     if (&EICUD11 == eicup) {
-      nvicDisableVector(STM32_TIM11_NUMBER);
       rccDisableTIM11();
     }
 #endif
 #if STM32_EICU_USE_TIM13
     if (&EICUD13 == eicup) {
-      nvicDisableVector(STM32_TIM13_NUMBER);
       rccDisableTIM13();
     }
 #endif
 #if STM32_EICU_USE_TIM14
     if (&EICUD14 == eicup) {
-      nvicDisableVector(STM32_TIM14_NUMBER);
       rccDisableTIM14();
     }
 #endif

--- a/os/hal/ports/STM32/LLD/TIMv1/stm32_tim1.inc
+++ b/os/hal/ports/STM32/LLD/TIMv1/stm32_tim1.inc
@@ -43,6 +43,9 @@
 #if !defined(STM32_ICU_USE_TIM1)
 #define STM32_ICU_USE_TIM1                  FALSE
 #endif
+#if !defined(STM32_EICU_USE_TIM1)
+#define STM32_EICU_USE_TIM1                 FALSE
+#endif
 #if !defined(STM32_PWM_USE_TIM1)
 #define STM32_PWM_USE_TIM1                  FALSE
 #endif
@@ -121,6 +124,11 @@ OSAL_IRQ_HANDLER(STM32_TIM1_UP_HANDLER) {
   icu_lld_serve_interrupt(&ICUD1);
 #endif
 #endif
+#if HAL_USE_EICU
+#if STM32_EICU_USE_TIM1
+  eicu_lld_serve_interrupt(&EICUD1);
+#endif
+#endif
 #if HAL_USE_PWM
 #if STM32_PWM_USE_TIM1
   pwm_lld_serve_interrupt(&PWMD1);
@@ -150,6 +158,11 @@ OSAL_IRQ_HANDLER(STM32_TIM1_CC_HANDLER) {
 #if HAL_USE_ICU
 #if STM32_ICU_USE_TIM1
   icu_lld_serve_interrupt(&ICUD1);
+#endif
+#endif
+#if HAL_USE_EICU
+#if STM32_EICU_USE_TIM1
+  eicu_lld_serve_interrupt(&EICUD1);
 #endif
 #endif
 #if HAL_USE_PWM

--- a/os/hal/ports/STM32/LLD/TIMv1/stm32_tim12.inc
+++ b/os/hal/ports/STM32/LLD/TIMv1/stm32_tim12.inc
@@ -43,6 +43,9 @@
 #if !defined(STM32_ICU_USE_TIM12)
 #define STM32_ICU_USE_TIM12                 FALSE
 #endif
+#if !defined(STM32_EICU_USE_TIM12)
+#define STM32_EICU_USE_TIM12                FALSE
+#endif
 #if !defined(STM32_PWM_USE_TIM12)
 #define STM32_PWM_USE_TIM12                 FALSE
 #endif
@@ -109,6 +112,11 @@ OSAL_IRQ_HANDLER(STM32_TIM12_HANDLER) {
 #if HAL_USE_ICU
 #if STM32_ICU_USE_TIM12
   icu_lld_serve_interrupt(&ICUD12);
+#endif
+#endif
+#if HAL_USE_EICU
+#if STM32_EICU_USE_TIM12
+  eicu_lld_serve_interrupt(&EICUD12);
 #endif
 #endif
 #if HAL_USE_PWM

--- a/os/hal/ports/STM32/LLD/TIMv1/stm32_tim13.inc
+++ b/os/hal/ports/STM32/LLD/TIMv1/stm32_tim13.inc
@@ -43,6 +43,9 @@
 #if !defined(STM32_ICU_USE_TIM13)
 #define STM32_ICU_USE_TIM13                 FALSE
 #endif
+#if !defined(STM32_EICU_USE_TIM13)
+#define STM32_EICU_USE_TIM13                FALSE
+#endif
 #if !defined(STM32_PWM_USE_TIM13)
 #define STM32_PWM_USE_TIM13                 FALSE
 #endif
@@ -109,6 +112,11 @@ OSAL_IRQ_HANDLER(STM32_TIM13_HANDLER) {
 #if HAL_USE_ICU
 #if STM32_ICU_USE_TIM13
   icu_lld_serve_interrupt(&ICUD13);
+#endif
+#endif
+#if HAL_USE_EICU
+#if STM32_EICU_USE_TIM13
+  eicu_lld_serve_interrupt(&EICUD13);
 #endif
 #endif
 #if HAL_USE_PWM

--- a/os/hal/ports/STM32/LLD/TIMv1/stm32_tim14.inc
+++ b/os/hal/ports/STM32/LLD/TIMv1/stm32_tim14.inc
@@ -43,6 +43,9 @@
 #if !defined(STM32_ICU_USE_TIM14)
 #define STM32_ICU_USE_TIM14                 FALSE
 #endif
+#if !defined(STM32_EICU_USE_TIM14)
+#define STM32_EICU_USE_TIM14                FALSE
+#endif
 #if !defined(STM32_PWM_USE_TIM14)
 #define STM32_PWM_USE_TIM14                 FALSE
 #endif
@@ -109,6 +112,11 @@ OSAL_IRQ_HANDLER(STM32_TIM14_HANDLER) {
 #if HAL_USE_ICU
 #if STM32_ICU_USE_TIM14
   icu_lld_serve_interrupt(&ICUD14);
+#endif
+#endif
+#if HAL_USE_EICU
+#if STM32_EICU_USE_TIM14
+  eicu_lld_serve_interrupt(&EICUD14);
 #endif
 #endif
 #if HAL_USE_PWM

--- a/os/hal/ports/STM32/LLD/TIMv1/stm32_tim15.inc
+++ b/os/hal/ports/STM32/LLD/TIMv1/stm32_tim15.inc
@@ -43,6 +43,9 @@
 #if !defined(STM32_ICU_USE_TIM15)
 #define STM32_ICU_USE_TIM15                 FALSE
 #endif
+#if !defined(STM32_EICU_USE_TIM15)
+#define STM32_EICU_USE_TIM15                FALSE
+#endif
 #if !defined(STM32_PWM_USE_TIM15)
 #define STM32_PWM_USE_TIM15                 FALSE
 #endif
@@ -109,6 +112,11 @@ OSAL_IRQ_HANDLER(STM32_TIM15_HANDLER) {
 #if HAL_USE_ICU
 #if STM32_ICU_USE_TIM15
   icu_lld_serve_interrupt(&ICUD15);
+#endif
+#endif
+#if HAL_USE_EICU
+#if STM32_EICU_USE_TIM15
+  eicu_lld_serve_interrupt(&EICUD15);
 #endif
 #endif
 #if HAL_USE_PWM

--- a/os/hal/ports/STM32/LLD/TIMv1/stm32_tim16.inc
+++ b/os/hal/ports/STM32/LLD/TIMv1/stm32_tim16.inc
@@ -43,6 +43,9 @@
 #if !defined(STM32_ICU_USE_TIM16)
 #define STM32_ICU_USE_TIM16                 FALSE
 #endif
+#if !defined(STM32_EICU_USE_TIM16)
+#define STM32_EICU_USE_TIM16                FALSE
+#endif
 #if !defined(STM32_PWM_USE_TIM16)
 #define STM32_PWM_USE_TIM16                 FALSE
 #endif
@@ -109,6 +112,11 @@ OSAL_IRQ_HANDLER(STM32_TIM16_HANDLER) {
 #if HAL_USE_ICU
 #if STM32_ICU_USE_TIM16
   icu_lld_serve_interrupt(&ICUD16);
+#endif
+#endif
+#if HAL_USE_EICU
+#if STM32_EICU_USE_TIM16
+  eicu_lld_serve_interrupt(&EICUD16);
 #endif
 #endif
 #if HAL_USE_PWM

--- a/os/hal/ports/STM32/LLD/TIMv1/stm32_tim17.inc
+++ b/os/hal/ports/STM32/LLD/TIMv1/stm32_tim17.inc
@@ -43,6 +43,9 @@
 #if !defined(STM32_ICU_USE_TIM17)
 #define STM32_ICU_USE_TIM17                 FALSE
 #endif
+#if !defined(STM32_EICU_USE_TIM17)
+#define STM32_EICU_USE_TIM17                FALSE
+#endif
 #if !defined(STM32_PWM_USE_TIM17)
 #define STM32_PWM_USE_TIM17                 FALSE
 #endif
@@ -109,6 +112,11 @@ OSAL_IRQ_HANDLER(STM32_TIM17_HANDLER) {
 #if HAL_USE_ICU
 #if STM32_ICU_USE_TIM17
   icu_lld_serve_interrupt(&ICUD17);
+#endif
+#endif
+#if HAL_USE_EICU
+#if STM32_EICU_USE_TIM17
+  eicu_lld_serve_interrupt(&EICUD17);
 #endif
 #endif
 #if HAL_USE_PWM

--- a/os/hal/ports/STM32/LLD/TIMv1/stm32_tim1_15_16_17.inc
+++ b/os/hal/ports/STM32/LLD/TIMv1/stm32_tim1_15_16_17.inc
@@ -55,6 +55,9 @@
 #if !defined(STM32_ICU_USE_TIM1)
 #define STM32_ICU_USE_TIM1                  FALSE
 #endif
+#if !defined(STM32_EICU_USE_TIM1)
+#define STM32_EICU_USE_TIM1                 FALSE
+#endif
 #if !defined(STM32_PWM_USE_TIM1)
 #define STM32_PWM_USE_TIM1                  FALSE
 #endif
@@ -67,6 +70,9 @@
 #endif
 #if !defined(STM32_ICU_USE_TIM15)
 #define STM32_ICU_USE_TIM15                 FALSE
+#endif
+#if !defined(STM32_EICU_USE_TIM15)
+#define STM32_EICU_USE_TIM15                FALSE
 #endif
 #if !defined(STM32_PWM_USE_TIM15)
 #define STM32_PWM_USE_TIM15                 FALSE
@@ -81,6 +87,9 @@
 #if !defined(STM32_ICU_USE_TIM16)
 #define STM32_ICU_USE_TIM16                 FALSE
 #endif
+#if !defined(STM32_EICU_USE_TIM16)
+#define STM32_EICU_USE_TIM16                FALSE
+#endif
 #if !defined(STM32_PWM_USE_TIM16)
 #define STM32_PWM_USE_TIM16                 FALSE
 #endif
@@ -93,6 +102,9 @@
 #endif
 #if !defined(STM32_ICU_USE_TIM17)
 #define STM32_ICU_USE_TIM17                 FALSE
+#endif
+#if !defined(STM32_EICU_USE_TIM17)
+#define STM32_EICU_USE_TIM17                FALSE
 #endif
 #if !defined(STM32_PWM_USE_TIM17)
 #define STM32_PWM_USE_TIM17                 FALSE
@@ -209,6 +221,11 @@ OSAL_IRQ_HANDLER(STM32_TIM1_BRK_TIM15_HANDLER) {
   icu_lld_serve_interrupt(&ICUD15);
 #endif
 #endif
+#if HAL_USE_EICU
+#if STM32_EICU_USE_TIM15
+  eicu_lld_serve_interrupt(&EICUD15);
+#endif
+#endif
 #if HAL_USE_PWM
 #if STM32_PWM_USE_TIM15
   pwm_lld_serve_interrupt(&PWMD15);
@@ -246,6 +263,11 @@ OSAL_IRQ_HANDLER(STM32_TIM1_UP_TIM16_HANDLER) {
 #if HAL_USE_ICU
 #if STM32_ICU_USE_TIM1
   icu_lld_serve_interrupt(&ICUD1);
+#endif
+#endif
+#if HAL_USE_EICU
+#if STM32_EICU_USE_TIM1
+  eicu_lld_serve_interrupt(&EICUD1);
 #endif
 #endif
 #if HAL_USE_PWM
@@ -319,6 +341,11 @@ OSAL_IRQ_HANDLER(STM32_TIM1_CC_HANDLER) {
 #if HAL_USE_ICU
 #if STM32_ICU_USE_TIM1
   icu_lld_serve_interrupt(&ICUD1);
+#endif
+#endif
+#if HAL_USE_EICU
+#if STM32_EICU_USE_TIM1
+  eicu_lld_serve_interrupt(&EICUD1);
 #endif
 #endif
 #if HAL_USE_PWM

--- a/os/hal/ports/STM32/LLD/TIMv1/stm32_tim1_16_17.inc
+++ b/os/hal/ports/STM32/LLD/TIMv1/stm32_tim1_16_17.inc
@@ -51,6 +51,9 @@
 #if !defined(STM32_ICU_USE_TIM1)
 #define STM32_ICU_USE_TIM1                  FALSE
 #endif
+#if !defined(STM32_EICU_USE_TIM1)
+#define STM32_EICU_USE_TIM1                 FALSE
+#endif
 #if !defined(STM32_PWM_USE_TIM1)
 #define STM32_PWM_USE_TIM1                  FALSE
 #endif
@@ -64,6 +67,9 @@
 #if !defined(STM32_ICU_USE_TIM16)
 #define STM32_ICU_USE_TIM16                 FALSE
 #endif
+#if !defined(STM32_EICU_USE_TIM16)
+#define STM32_EICU_USE_TIM16                FALSE
+#endif
 #if !defined(STM32_PWM_USE_TIM16)
 #define STM32_PWM_USE_TIM16                 FALSE
 #endif
@@ -76,6 +82,9 @@
 #endif
 #if !defined(STM32_ICU_USE_TIM17)
 #define STM32_ICU_USE_TIM17                 FALSE
+#endif
+#if !defined(STM32_EICU_USE_TIM17)
+#define STM32_EICU_USE_TIM17                FALSE
 #endif
 #if !defined(STM32_PWM_USE_TIM17)
 #define STM32_PWM_USE_TIM17                 FALSE
@@ -208,6 +217,11 @@ OSAL_IRQ_HANDLER(STM32_TIM1_UP_TIM16_HANDLER) {
   icu_lld_serve_interrupt(&ICUD1);
 #endif
 #endif
+#if HAL_USE_EICU
+#if STM32_EICU_USE_TIM1
+  eicu_lld_serve_interrupt(&EICUD1);
+#endif
+#endif
 #if HAL_USE_PWM
 #if STM32_PWM_USE_TIM1
   pwm_lld_serve_interrupt(&PWMD1);
@@ -279,6 +293,11 @@ OSAL_IRQ_HANDLER(STM32_TIM1_CC_HANDLER) {
 #if HAL_USE_ICU
 #if STM32_ICU_USE_TIM1
   icu_lld_serve_interrupt(&ICUD1);
+#endif
+#endif
+#if HAL_USE_EICU
+#if STM32_EICU_USE_TIM1
+  eicu_lld_serve_interrupt(&EICUD1);
 #endif
 #endif
 #if HAL_USE_PWM

--- a/os/hal/ports/STM32/LLD/TIMv1/stm32_tim1_9_10_11.inc
+++ b/os/hal/ports/STM32/LLD/TIMv1/stm32_tim1_9_10_11.inc
@@ -55,6 +55,9 @@
 #if !defined(STM32_ICU_USE_TIM1)
 #define STM32_ICU_USE_TIM1                  FALSE
 #endif
+#if !defined(STM32_EICU_USE_TIM1)
+#define STM32_EICU_USE_TIM1                 FALSE
+#endif
 #if !defined(STM32_PWM_USE_TIM1)
 #define STM32_PWM_USE_TIM1                  FALSE
 #endif
@@ -84,6 +87,9 @@
 #if !defined(STM32_ICU_USE_TIM10)
 #define STM32_ICU_USE_TIM10                 FALSE
 #endif
+#if !defined(STM32_EICU_USE_TIM10)
+#define STM32_EICU_USE_TIM10                FALSE
+#endif
 #if !defined(STM32_PWM_USE_TIM10)
 #define STM32_PWM_USE_TIM10                 FALSE
 #endif
@@ -96,6 +102,9 @@
 #endif
 #if !defined(STM32_ICU_USE_TIM11)
 #define STM32_ICU_USE_TIM11                 FALSE
+#endif
+#if !defined(STM32_EICU_USE_TIM11)
+#define STM32_EICU_USE_TIM11                FALSE
 #endif
 #if !defined(STM32_PWM_USE_TIM11)
 #define STM32_PWM_USE_TIM11                 FALSE
@@ -259,6 +268,14 @@ OSAL_IRQ_HANDLER(STM32_TIM1_UP_TIM10_HANDLER) {
   icu_lld_serve_interrupt(&ICUD10);
 #endif
 #endif
+#if HAL_USE_EICU
+#if STM32_EICU_USE_TIM1
+  eicu_lld_serve_interrupt(&EICUD1);
+#endif
+#if STM32_EICU_USE_TIM10
+  eicu_lld_serve_interrupt(&EICUD10);
+#endif
+#endif
 #if HAL_USE_PWM
 #if STM32_PWM_USE_TIM1
   pwm_lld_serve_interrupt(&PWMD1);
@@ -301,6 +318,11 @@ OSAL_IRQ_HANDLER(STM32_TIM1_TRGCO_TIM11_HANDLER) {
   icu_lld_serve_interrupt(&ICUD11);
 #endif
 #endif
+#if HAL_USE_EICU
+#if STM32_EICU_USE_TIM11
+  eicu_lld_serve_interrupt(&EICUD11);
+#endif
+#endif
 #if HAL_USE_PWM
 #if STM32_PWM_USE_TIM11
   pwm_lld_serve_interrupt(&PWMD11);
@@ -332,6 +354,11 @@ OSAL_IRQ_HANDLER(STM32_TIM1_CC_HANDLER) {
 #if HAL_USE_ICU
 #if STM32_ICU_USE_TIM1
   icu_lld_serve_interrupt(&ICUD1);
+#endif
+#endif
+#if HAL_USE_EICU
+#if STM32_EICU_USE_TIM1
+  eicu_lld_serve_interrupt(&EICUD1);
 #endif
 #endif
 #if HAL_USE_PWM

--- a/os/hal/ports/STM32/LLD/TIMv1/stm32_tim1_shared.inc
+++ b/os/hal/ports/STM32/LLD/TIMv1/stm32_tim1_shared.inc
@@ -43,6 +43,9 @@
 #if !defined(STM32_ICU_USE_TIM1)
 #define STM32_ICU_USE_TIM1                  FALSE
 #endif
+#if !defined(STM32_EICU_USE_TIM1)
+#define STM32_EICU_USE_TIM1                 FALSE
+#endif
 #if !defined(STM32_PWM_USE_TIM1)
 #define STM32_PWM_USE_TIM1                  FALSE
 #endif
@@ -105,6 +108,11 @@ OSAL_IRQ_HANDLER(STM32_TIM1_SHARED_HANDLER) {
 #if HAL_USE_ICU
 #if STM32_ICU_USE_TIM1
   icu_lld_serve_interrupt(&ICUD1);
+#endif
+#endif
+#if HAL_USE_EICU
+#if STM32_EICU_USE_TIM1
+  eicu_lld_serve_interrupt(&EICUD1);
 #endif
 #endif
 #if HAL_USE_PWM

--- a/os/hal/ports/STM32/LLD/TIMv1/stm32_tim2.inc
+++ b/os/hal/ports/STM32/LLD/TIMv1/stm32_tim2.inc
@@ -43,6 +43,9 @@
 #if !defined(STM32_ICU_USE_TIM2)
 #define STM32_ICU_USE_TIM2                  FALSE
 #endif
+#if !defined(STM32_EICU_USE_TIM2)
+#define STM32_EICU_USE_TIM2                 FALSE
+#endif
 #if !defined(STM32_PWM_USE_TIM2)
 #define STM32_PWM_USE_TIM2                  FALSE
 #endif
@@ -109,6 +112,11 @@ OSAL_IRQ_HANDLER(STM32_TIM2_HANDLER) {
 #if HAL_USE_ICU
 #if STM32_ICU_USE_TIM2
   icu_lld_serve_interrupt(&ICUD2);
+#endif
+#endif
+#if HAL_USE_EICU
+#if STM32_EICU_USE_TIM2
+  eicu_lld_serve_interrupt(&EICUD2);
 #endif
 #endif
 #if HAL_USE_PWM

--- a/os/hal/ports/STM32/LLD/TIMv1/stm32_tim20.inc
+++ b/os/hal/ports/STM32/LLD/TIMv1/stm32_tim20.inc
@@ -43,6 +43,9 @@
 #if !defined(STM32_ICU_USE_TIM20)
 #define STM32_ICU_USE_TIM20                 FALSE
 #endif
+#if !defined(STM32_EICU_USE_TIM20)
+#define STM32_EICU_USE_TIM20                FALSE
+#endif
 #if !defined(STM32_PWM_USE_TIM20)
 #define STM32_PWM_USE_TIM20                 FALSE
 #endif
@@ -118,7 +121,12 @@ OSAL_IRQ_HANDLER(STM32_TIM20_UP_HANDLER) {
 #endif
 #if HAL_USE_ICU
 #if STM32_ICU_USE_TIM20
-  pwm_lld_serve_interrupt(&ICUD20);
+  icu_lld_serve_interrupt(&ICUD20);
+#endif
+#endif
+#if HAL_USE_EICU
+#if STM32_EICU_USE_TIM20
+  eicu_lld_serve_interrupt(&EICUD20);
 #endif
 #endif
 #if HAL_USE_PWM
@@ -148,7 +156,10 @@ OSAL_IRQ_HANDLER(STM32_TIM20_CC_HANDLER) {
   /* Not used by GPT.*/
 #endif
 #if STM32_ICU_USE_TIM20
-  pwm_lld_serve_interrupt(&ICUD20);
+  icu_lld_serve_interrupt(&ICUD20);
+#endif
+#if STM32_EICU_USE_TIM20
+  eicu_lld_serve_interrupt(&EICUD20);
 #endif
 #if HAL_USE_PWM
 #if STM32_PWM_USE_TIM20

--- a/os/hal/ports/STM32/LLD/TIMv1/stm32_tim21.inc
+++ b/os/hal/ports/STM32/LLD/TIMv1/stm32_tim21.inc
@@ -43,6 +43,9 @@
 #if !defined(STM32_ICU_USE_TIM21)
 #define STM32_ICU_USE_TIM21                 FALSE
 #endif
+#if !defined(STM32_EICU_USE_TIM21)
+#define STM32_EICU_USE_TIM21                FALSE
+#endif
 #if !defined(STM32_PWM_USE_TIM21)
 #define STM32_PWM_USE_TIM21                 FALSE
 #endif
@@ -109,6 +112,11 @@ OSAL_IRQ_HANDLER(STM32_TIM21_HANDLER) {
 #if HAL_USE_ICU
 #if STM32_ICU_USE_TIM21
   icu_lld_serve_interrupt(&ICUD21);
+#endif
+#endif
+#if HAL_USE_EICU
+#if STM32_EICU_USE_TIM21
+  eicu_lld_serve_interrupt(&EICUD21);
 #endif
 #endif
 #if HAL_USE_PWM

--- a/os/hal/ports/STM32/LLD/TIMv1/stm32_tim22.inc
+++ b/os/hal/ports/STM32/LLD/TIMv1/stm32_tim22.inc
@@ -43,6 +43,9 @@
 #if !defined(STM32_ICU_USE_TIM22)
 #define STM32_ICU_USE_TIM22                 FALSE
 #endif
+#if !defined(STM32_EICU_USE_TIM22)
+#define STM32_EICU_USE_TIM22                FALSE
+#endif
 #if !defined(STM32_PWM_USE_TIM22)
 #define STM32_PWM_USE_TIM22                 FALSE
 #endif
@@ -109,6 +112,11 @@ OSAL_IRQ_HANDLER(STM32_TIM22_HANDLER) {
 #if HAL_USE_ICU
 #if STM32_ICU_USE_TIM22
   icu_lld_serve_interrupt(&ICUD22);
+#endif
+#endif
+#if HAL_USE_EICU
+#if STM32_EICU_USE_TIM22
+  eicu_lld_serve_interrupt(&EICUD22);
 #endif
 #endif
 #if HAL_USE_PWM

--- a/os/hal/ports/STM32/LLD/TIMv1/stm32_tim3.inc
+++ b/os/hal/ports/STM32/LLD/TIMv1/stm32_tim3.inc
@@ -43,6 +43,9 @@
 #if !defined(STM32_ICU_USE_TIM3)
 #define STM32_ICU_USE_TIM3                  FALSE
 #endif
+#if !defined(STM32_EICU_USE_TIM3)
+#define STM32_EICU_USE_TIM3                 FALSE
+#endif
 #if !defined(STM32_PWM_USE_TIM3)
 #define STM32_PWM_USE_TIM3                  FALSE
 #endif
@@ -109,6 +112,11 @@ OSAL_IRQ_HANDLER(STM32_TIM3_HANDLER) {
 #if HAL_USE_ICU
 #if STM32_ICU_USE_TIM3
   icu_lld_serve_interrupt(&ICUD3);
+#endif
+#endif
+#if HAL_USE_EICU
+#if STM32_EICU_USE_TIM3
+  eicu_lld_serve_interrupt(&EICUD3);
 #endif
 #endif
 #if HAL_USE_PWM

--- a/os/hal/ports/STM32/LLD/TIMv1/stm32_tim3_4.inc
+++ b/os/hal/ports/STM32/LLD/TIMv1/stm32_tim3_4.inc
@@ -56,6 +56,9 @@
 #if !defined(STM32_ICU_USE_TIM3)
 #define STM32_ICU_USE_TIM3                  FALSE
 #endif
+#if !defined(STM32_EICU_USE_TIM3)
+#define STM32_EICU_USE_TIM3                 FALSE
+#endif
 #if !defined(STM32_PWM_USE_TIM3)
 #define STM32_PWM_USE_TIM3                  FALSE
 #endif
@@ -68,6 +71,9 @@
 #endif
 #if !defined(STM32_ICU_USE_TIM4)
 #define STM32_ICU_USE_TIM4                  FALSE
+#endif
+#if !defined(STM32_EICU_USE_TIM4)
+#define STM32_EICU_USE_TIM4                 FALSE
 #endif
 #if !defined(STM32_PWM_USE_TIM4)
 #define STM32_PWM_USE_TIM4                  FALSE
@@ -145,6 +151,14 @@ OSAL_IRQ_HANDLER(STM32_TIM3_TIM4_HANDLER) {
 #endif
 #if STM32_ICU_USE_TIM4
   icu_lld_serve_interrupt(&ICUD4);
+#endif
+#endif
+#if HAL_USE_EICU
+#if STM32_EICU_USE_TIM3
+  eicu_lld_serve_interrupt(&EICUD3);
+#endif
+#if STM32_EICU_USE_TIM4
+  eicu_lld_serve_interrupt(&EICUD4);
 #endif
 #endif
 #if HAL_USE_PWM

--- a/os/hal/ports/STM32/LLD/TIMv1/stm32_tim4.inc
+++ b/os/hal/ports/STM32/LLD/TIMv1/stm32_tim4.inc
@@ -43,6 +43,9 @@
 #if !defined(STM32_ICU_USE_TIM4)
 #define STM32_ICU_USE_TIM4                  FALSE
 #endif
+#if !defined(STM32_EICU_USE_TIM4)
+#define STM32_EICU_USE_TIM4                 FALSE
+#endif
 #if !defined(STM32_PWM_USE_TIM4)
 #define STM32_PWM_USE_TIM4                  FALSE
 #endif
@@ -109,6 +112,11 @@ OSAL_IRQ_HANDLER(STM32_TIM4_HANDLER) {
 #if HAL_USE_ICU
 #if STM32_ICU_USE_TIM4
   icu_lld_serve_interrupt(&ICUD4);
+#endif
+#endif
+#if HAL_USE_EICU
+#if STM32_EICU_USE_TIM4
+  eicu_lld_serve_interrupt(&EICUD4);
 #endif
 #endif
 #if HAL_USE_PWM

--- a/os/hal/ports/STM32/LLD/TIMv1/stm32_tim5.inc
+++ b/os/hal/ports/STM32/LLD/TIMv1/stm32_tim5.inc
@@ -43,6 +43,9 @@
 #if !defined(STM32_ICU_USE_TIM5)
 #define STM32_ICU_USE_TIM5                  FALSE
 #endif
+#if !defined(STM32_EICU_USE_TIM5)
+#define STM32_EICU_USE_TIM5                 FALSE
+#endif
 #if !defined(STM32_PWM_USE_TIM5)
 #define STM32_PWM_USE_TIM5                  FALSE
 #endif
@@ -109,6 +112,11 @@ OSAL_IRQ_HANDLER(STM32_TIM5_HANDLER) {
 #if HAL_USE_ICU
 #if STM32_ICU_USE_TIM5
   icu_lld_serve_interrupt(&ICUD5);
+#endif
+#endif
+#if HAL_USE_EICU
+#if STM32_EICU_USE_TIM5
+  eicu_lld_serve_interrupt(&EICUD5);
 #endif
 #endif
 #if HAL_USE_PWM

--- a/os/hal/ports/STM32/LLD/TIMv1/stm32_tim6.inc
+++ b/os/hal/ports/STM32/LLD/TIMv1/stm32_tim6.inc
@@ -43,6 +43,9 @@
 #if !defined(STM32_ICU_USE_TIM6)
 #define STM32_ICU_USE_TIM6                  FALSE
 #endif
+#if !defined(STM32_EICU_USE_TIM6)
+#define STM32_EICU_USE_TIM6                 FALSE
+#endif
 #if !defined(STM32_PWM_USE_TIM6)
 #define STM32_PWM_USE_TIM6                  FALSE
 #endif
@@ -109,6 +112,11 @@ OSAL_IRQ_HANDLER(STM32_TIM6_HANDLER) {
 #if HAL_USE_ICU
 #if STM32_ICU_USE_TIM6
   icu_lld_serve_interrupt(&ICUD6);
+#endif
+#endif
+#if HAL_USE_EICU
+#if STM32_EICU_USE_TIM6
+  eicu_lld_serve_interrupt(&EICUD6);
 #endif
 #endif
 #if HAL_USE_PWM

--- a/os/hal/ports/STM32/LLD/TIMv1/stm32_tim7.inc
+++ b/os/hal/ports/STM32/LLD/TIMv1/stm32_tim7.inc
@@ -43,6 +43,9 @@
 #if !defined(STM32_ICU_USE_TIM7)
 #define STM32_ICU_USE_TIM7                  FALSE
 #endif
+#if !defined(STM32_EICU_USE_TIM7)
+#define STM32_EICU_USE_TIM7                 FALSE
+#endif
 #if !defined(STM32_PWM_USE_TIM7)
 #define STM32_PWM_USE_TIM7                  FALSE
 #endif
@@ -109,6 +112,11 @@ OSAL_IRQ_HANDLER(STM32_TIM7_HANDLER) {
 #if HAL_USE_ICU
 #if STM32_ICU_USE_TIM7
   icu_lld_serve_interrupt(&ICUD7);
+#endif
+#endif
+#if HAL_USE_EICU
+#if STM32_EICU_USE_TIM7
+  eicu_lld_serve_interrupt(&EICUD7);
 #endif
 #endif
 #if HAL_USE_PWM

--- a/os/hal/ports/STM32/LLD/TIMv1/stm32_tim8.inc
+++ b/os/hal/ports/STM32/LLD/TIMv1/stm32_tim8.inc
@@ -43,6 +43,9 @@
 #if !defined(STM32_ICU_USE_TIM8)
 #define STM32_ICU_USE_TIM8                  FALSE
 #endif
+#if !defined(STM32_EICU_USE_TIM8)
+#define STM32_EICU_USE_TIM8                 FALSE
+#endif
 #if !defined(STM32_PWM_USE_TIM8)
 #define STM32_PWM_USE_TIM8                  FALSE
 #endif
@@ -121,6 +124,11 @@ OSAL_IRQ_HANDLER(STM32_TIM8_UP_HANDLER) {
   icu_lld_serve_interrupt(&ICUD8);
 #endif
 #endif
+#if HAL_USE_EICU
+#if STM32_EICU_USE_TIM8
+  eicu_lld_serve_interrupt(&EICUD8);
+#endif
+#endif
 #if HAL_USE_PWM
 #if STM32_PWM_USE_TIM8
   pwm_lld_serve_interrupt(&PWMD8);
@@ -150,6 +158,11 @@ OSAL_IRQ_HANDLER(STM32_TIM8_CC_HANDLER) {
 #if HAL_USE_ICU
 #if STM32_ICU_USE_TIM8
   icu_lld_serve_interrupt(&ICUD8);
+#endif
+#endif
+#if HAL_USE_EICU
+#if STM32_EICU_USE_TIM8
+  eicu_lld_serve_interrupt(&EICUD8);
 #endif
 #endif
 #if HAL_USE_PWM

--- a/os/hal/ports/STM32/LLD/TIMv1/stm32_tim8_12_13_14.inc
+++ b/os/hal/ports/STM32/LLD/TIMv1/stm32_tim8_12_13_14.inc
@@ -55,6 +55,9 @@
 #if !defined(STM32_ICU_USE_TIM8)
 #define STM32_ICU_USE_TIM8                  FALSE
 #endif
+#if !defined(STM32_EICU_USE_TIM8)
+#define STM32_EICU_USE_TIM8                 FALSE
+#endif
 #if !defined(STM32_PWM_USE_TIM8)
 #define STM32_PWM_USE_TIM8                  FALSE
 #endif
@@ -67,6 +70,9 @@
 #endif
 #if !defined(STM32_ICU_USE_TIM12)
 #define STM32_ICU_USE_TIM12                 FALSE
+#endif
+#if !defined(STM32_EICU_USE_TIM12)
+#define STM32_EICU_USE_TIM12                FALSE
 #endif
 #if !defined(STM32_PWM_USE_TIM12)
 #define STM32_PWM_USE_TIM12                 FALSE
@@ -81,6 +87,9 @@
 #if !defined(STM32_ICU_USE_TIM13)
 #define STM32_ICU_USE_TIM13                 FALSE
 #endif
+#if !defined(STM32_EICU_USE_TIM13)
+#define STM32_EICU_USE_TIM13                FALSE
+#endif
 #if !defined(STM32_PWM_USE_TIM13)
 #define STM32_PWM_USE_TIM13                 FALSE
 #endif
@@ -93,6 +102,9 @@
 #endif
 #if !defined(STM32_ICU_USE_TIM14)
 #define STM32_ICU_USE_TIM14                 FALSE
+#endif
+#if !defined(STM32_EICU_USE_TIM14)
+#define STM32_EICU_USE_TIM14                FALSE
 #endif
 #if !defined(STM32_PWM_USE_TIM14)
 #define STM32_PWM_USE_TIM14                 FALSE
@@ -209,6 +221,11 @@ OSAL_IRQ_HANDLER(STM32_TIM8_BRK_TIM12_HANDLER) {
   icu_lld_serve_interrupt(&ICUD12);
 #endif
 #endif
+#if HAL_USE_EICU
+#if STM32_EICU_USE_TIM12
+  eicu_lld_serve_interrupt(&EICUD12);
+#endif
+#endif
 #if HAL_USE_PWM
 #if STM32_PWM_USE_TIM12
   pwm_lld_serve_interrupt(&PWMD12);
@@ -249,6 +266,14 @@ OSAL_IRQ_HANDLER(STM32_TIM8_UP_TIM13_HANDLER) {
 #endif
 #if STM32_ICU_USE_TIM13
   icu_lld_serve_interrupt(&ICUD13);
+#endif
+#endif
+#if HAL_USE_EICU
+#if STM32_EICU_USE_TIM8
+  eicu_lld_serve_interrupt(&EICUD8);
+#endif
+#if STM32_EICU_USE_TIM13
+  eicu_lld_serve_interrupt(&EICUD13);
 #endif
 #endif
 #if HAL_USE_PWM
@@ -293,6 +318,11 @@ OSAL_IRQ_HANDLER(STM32_TIM8_TRGCO_TIM14_HANDLER) {
   icu_lld_serve_interrupt(&ICUD14);
 #endif
 #endif
+#if HAL_USE_EICU
+#if STM32_EICU_USE_TIM14
+  eicu_lld_serve_interrupt(&EICUD14);
+#endif
+#endif
 #if HAL_USE_PWM
 #if STM32_PWM_USE_TIM14
   pwm_lld_serve_interrupt(&PWMD14);
@@ -324,6 +354,11 @@ OSAL_IRQ_HANDLER(STM32_TIM8_CC_HANDLER) {
 #if HAL_USE_ICU
 #if STM32_ICU_USE_TIM8
   icu_lld_serve_interrupt(&ICUD8);
+#endif
+#endif
+#if HAL_USE_EICU
+#if STM32_EICU_USE_TIM8
+  eicu_lld_serve_interrupt(&EICUD8);
 #endif
 #endif
 #if HAL_USE_PWM


### PR DESCRIPTION
The port of the 3rd-party EICU code missed some ISRs on some chips.

This is essentially a copy and paste of the ICU architecture for EICU