### PR TITLE
ADCv4: add support to select ADC12 DUAL operation mode

### DIFF
--- a/os/hal/ports/STM32/LLD/ADCv4/hal_adc_lld.c
+++ b/os/hal/ports/STM32/LLD/ADCv4/hal_adc_lld.c
@@ -31,7 +31,9 @@
 /*===========================================================================*/
 
 #if STM32_ADC_DUAL_MODE == TRUE
+#ifndef ADC12_CCR_DUAL
 #define ADC12_CCR_DUAL  ADC_CCR_DUAL_REG_SIMULT
+#endif
 #if STM32_ADC_SAMPLES_SIZE == 8
 /* Compact type dual mode, 2x8-bit.*/
 #define ADC12_DMA_SIZE  (STM32_DMA_CR_MSIZE_HWORD | STM32_DMA_CR_PSIZE_HWORD)


### PR DESCRIPTION
For some reason while using ADC Dual mode the samples from ADC2 are getting shifted in order in memory, starting of as correct and then misbehaving almost immediately. The issue goes away when using interleaved sampling instead of simultaneous. So for now we can select interleaved sampling for Dual mode operation in ardupilot.