### PR TITLE
hal_mmc_spi: fix multi-block reads

### DIFF
--- a/os/hal/src/hal_mmc_spi.c
+++ b/os/hal/src/hal_mmc_spi.c
@@ -191,10 +191,10 @@ static bool mmc_read(void *instance, uint32_t startblk,
       }
       buffer += MMCSD_BLOCK_SIZE;
       n--;
+    }
 
-      if (mmcStopSequentialRead(mmcp)) {
-        break;
-      }
+    if (mmcStopSequentialRead(mmcp)) {
+      break;
     }
 
     err = HAL_SUCCESS;


### PR DESCRIPTION
MMC SPI would only ever read 512 bytes