### PR TITLE
mmc_spi: added bus acquire hooks

### DIFF
--- a/os/hal/src/hal_mmc_spi.c
+++ b/os/hal/src/hal_mmc_spi.c
@@ -35,6 +35,8 @@
 #include "spi_hook.h"
 #define spiStart spiStartHook
 #define spiStop spiStopHook
+#define spiAcquireBus spiAcquireBusHook
+#define spiReleaseBus spiReleaseBusHook
 #define spiSelect spiSelectHook
 #define spiUnselect spiUnselectHook
 #define spiIgnore spiIgnoreHook


### PR DESCRIPTION
needed to ensure we get DMA lock before the bus lock, so we don't deadlock with another device on the same bus