### PR TITLE
FATFS: disable ff_memalloc function for ArduPilot

### DIFF
--- a/ext/fatfs/source/ffsystem.c
+++ b/ext/fatfs/source/ffsystem.c
@@ -13,13 +13,13 @@
 /* Allocate a memory block                                                */
 /*------------------------------------------------------------------------*/
 
+#ifndef _ARDUPILOT_
 void* ff_memalloc (	/* Returns pointer to the allocated memory block (null if not enough core) */
 	UINT msize		/* Number of bytes to allocate */
 )
 {
 	return malloc(msize);	/* Allocate a new memory block with POSIX API */
 }
-
 
 /*------------------------------------------------------------------------*/
 /* Free a memory block                                                    */
@@ -31,6 +31,7 @@ void ff_memfree (
 {
 	free(mblock);	/* Free the memory block with POSIX API */
 }
+#endif // _ARDUPILOT_
 
 #endif
 

--- a/os/various/fatfs_bindings/fatfs_syscall.c
+++ b/os/various/fatfs_bindings/fatfs_syscall.c
@@ -67,6 +67,7 @@ void ff_rel_grant(FF_SYNC_t sobj) {
 #endif /* FF_FS_REENTRANT */
 
 #if FF_USE_LFN == 3	/* LFN with a working buffer on the heap */
+#ifndef _ARDUPILOT_
 /*------------------------------------------------------------------------*/
 /* Allocate a memory block                                                */
 /*------------------------------------------------------------------------*/
@@ -82,4 +83,5 @@ void ff_memfree(void *mblock) {
 
   free(mblock);
 }
+#endif // _ARDUPILOT_
 #endif /* FF_USE_LFN == 3 */


### PR DESCRIPTION
move up to HAL_ChibiOS level