### PR TITLE
MAVv2: fixed shift of BOARD_PHY_ADDRESS

### DIFF
--- a/os/hal/ports/STM32/LLD/MACv2/hal_mac_lld.c
+++ b/os/hal/ports/STM32/LLD/MACv2/hal_mac_lld.c
@@ -321,7 +321,7 @@ bool mac_lld_init(void) {
 
   /* PHY address setup.*/
 #if defined(BOARD_PHY_ADDRESS)
-  ETHD1.phyaddr = BOARD_PHY_ADDRESS << 11;
+  ETHD1.phyaddr = BOARD_PHY_ADDRESS << ETH_MACMDIOAR_PA_Pos;
 #else
   if (!mii_find_phy(&ETHD1)) {
       rccDisableETH();


### PR DESCRIPTION
a shift of 11 is correct for MAVv1. In v2 it is 21, ETH_MACMDIOAR_PA_Pos