### PR TITLE
add entry hook called immediately on reset

### DIFF
--- a/os/common/startup/ARMCMx/compilers/GCC/crt0_v6m.S
+++ b/os/common/startup/ARMCMx/compilers/GCC/crt0_v6m.S
@@ -144,6 +144,13 @@
 #define CRT0_EXTRA_CORES_NUMBER             0
 #endif
 
+/**
+  * @brief   Entry Hook Enabled.
+  */
+#if !defined(CRT0_ENTRY_HOOK) || defined(__DOXYGEN__)
+#define CRT0_ENTRY_HOOK             FALSE
+#endif
+
 /*===========================================================================*/
 /* Code section.                                                             */
 /*===========================================================================*/
@@ -163,6 +170,10 @@
                 .thumb_func
                 .global _crt0_entry
 _crt0_entry:
+#if CRT0_ENTRY_HOOK == TRUE
+                ldr     R0, =__entry_hook
+                blx     R0
+#endif
                 /* Interrupts are globally masked initially.*/
                 cpsid   i
 

--- a/os/common/startup/ARMCMx/compilers/GCC/crt0_v7m.S
+++ b/os/common/startup/ARMCMx/compilers/GCC/crt0_v7m.S
@@ -177,6 +177,13 @@
 #define CRT0_CPACR_INIT                     0x00F00000
 #endif
 
+/**
+  * @brief   Entry Hook Enabled.
+  */
+#if !defined(CRT0_ENTRY_HOOK) || defined(__DOXYGEN__)
+#define CRT0_ENTRY_HOOK             FALSE
+#endif
+
 /*===========================================================================*/
 /* Code section.                                                             */
 /*===========================================================================*/
@@ -201,6 +208,10 @@
                 .thumb_func
                 .global _crt0_entry
 _crt0_entry:
+#if CRT0_ENTRY_HOOK == TRUE
+                ldr     R0, =__entry_hook
+                blx     R0
+#endif
                 /* Interrupts are globally masked initially.*/
                 cpsid   i
 

--- a/os/common/startup/ARMCMx/compilers/GCC/crt0_v7m.S
+++ b/os/common/startup/ARMCMx/compilers/GCC/crt0_v7m.S
@@ -208,6 +208,10 @@
                 .thumb_func
                 .global _crt0_entry
 _crt0_entry:
+#if CRT0_ENTRY_HOOK == TRUE
+                ldr     R0, =__entry_hook
+                blx     R0
+#endif
                 /* Interrupts are globally masked initially.*/
                 cpsid   i
 
@@ -352,11 +356,6 @@ bloop:
 #if CRT0_INIT_RAM_AREAS == TRUE
                 /* RAM areas initialization.*/
                 bl      __init_ram_areas
-#endif
-
-#if CRT0_ENTRY_HOOK == TRUE
-                ldr     R0, =__entry_hook
-                blx     R0
 #endif
 
                 /* Late initialization..*/

--- a/os/common/startup/ARMCMx/compilers/GCC/crt0_v7m.S
+++ b/os/common/startup/ARMCMx/compilers/GCC/crt0_v7m.S
@@ -208,10 +208,6 @@
                 .thumb_func
                 .global _crt0_entry
 _crt0_entry:
-#if CRT0_ENTRY_HOOK == TRUE
-                ldr     R0, =__entry_hook
-                blx     R0
-#endif
                 /* Interrupts are globally masked initially.*/
                 cpsid   i
 
@@ -356,6 +352,11 @@ bloop:
 #if CRT0_INIT_RAM_AREAS == TRUE
                 /* RAM areas initialization.*/
                 bl      __init_ram_areas
+#endif
+
+#if CRT0_ENTRY_HOOK == TRUE
+                ldr     R0, =__entry_hook
+                blx     R0
 #endif
 
                 /* Late initialization..*/

--- a/os/common/startup/ARMCMx/compilers/GCC/crt1.c
+++ b/os/common/startup/ARMCMx/compilers/GCC/crt1.c
@@ -147,6 +147,20 @@ void __cpu_init(void) {
 }
 
 /**
+ * @brief called immediately at Reset
+ * @details This hook is invoked immediately after the Reset Handler
+ * 
+ * @note    This function is a weak symbol.
+ */
+#if !defined(__DOXYGEN__)
+__attribute__((weak))
+#endif
+/*lint -save -e9075 [8.4] All symbols are invoked from asm context.*/
+#ifndef __ARDUPILOT__
+void __entry_hook(void) {}
+#endif
+
+/**
  * @brief   Early initialization.
  * @details This hook is invoked immediately after the stack and core
  *          initialization and before the DATA and BSS segments


### PR DESCRIPTION
Re-instates ff56b1cf144b8491b10a00be72a78a4d8e3866c2 which was lost during the upgrade