### PR TITLE
startup: add CRT0_ENTRY_HOOK for immediate reset handler callback

### DIFF
--- a/os/common/startup/ARMCMx/compilers/GCC/crt0_v6m.S
+++ b/os/common/startup/ARMCMx/compilers/GCC/crt0_v6m.S
@@ -138,6 +138,13 @@
 #endif
 
 /**
+  * @brief   Entry Hook Enabled.
+  */
+#if !defined(CRT0_ENTRY_HOOK) || defined(__DOXYGEN__)
+#define CRT0_ENTRY_HOOK             FALSE
+#endif
+
+/**
  * @brief   Number of extra cores.
  */
 #if !defined(CRT0_EXTRA_CORES_NUMBER) || defined(__DOXYGEN__)
@@ -163,6 +170,10 @@
                 .thumb_func
                 .global _crt0_entry
 _crt0_entry:
+#if CRT0_ENTRY_HOOK == TRUE
+                ldr     R0, =__entry_hook
+                blx     R0
+#endif
                 /* Interrupts are globally masked initially.*/
                 cpsid   i
 

--- a/os/common/startup/ARMCMx/compilers/GCC/crt0_v7m.S
+++ b/os/common/startup/ARMCMx/compilers/GCC/crt0_v7m.S
@@ -177,6 +177,13 @@
 #define CRT0_CPACR_INIT                     0x00F00000
 #endif
 
+/**
+  * @brief   Entry Hook Enabled.
+  */
+#if !defined(CRT0_ENTRY_HOOK) || defined(__DOXYGEN__)
+#define CRT0_ENTRY_HOOK             FALSE
+#endif
+
 /*===========================================================================*/
 /* Code section.                                                             */
 /*===========================================================================*/
@@ -201,6 +208,10 @@
                 .thumb_func
                 .global _crt0_entry
 _crt0_entry:
+#if CRT0_ENTRY_HOOK == TRUE
+                ldr     R0, =__entry_hook
+                blx     R0
+#endif
                 /* Interrupts are globally masked initially.*/
                 cpsid   i
 

--- a/os/common/startup/ARMCMx/compilers/GCC/crt1.c
+++ b/os/common/startup/ARMCMx/compilers/GCC/crt1.c
@@ -147,6 +147,20 @@ void __cpu_init(void) {
 }
 
 /**
+ * @brief called immediately at Reset
+ * @details This hook is invoked immediately after the Reset Handler
+ * 
+ * @note    This function is a weak symbol.
+ */
+#if !defined(__DOXYGEN__)
+__attribute__((weak))
+#endif
+/*lint -save -e9075 [8.4] All symbols are invoked from asm context.*/
+#ifndef _ARDUPILOT_
+void __entry_hook(void) {}
+#endif
+
+/**
  * @brief   Early initialization.
  * @details This hook is invoked immediately after the stack and core
  *          initialization and before the DATA and BSS segments


### PR DESCRIPTION
Add optional __entry_hook function called at the very start of _crt0_entry before interrupts are disabled. Disabled by default.

This allows ardupilot bootloader to catch DFU boot request and boot to DFU instead of continuing to Application boot.